### PR TITLE
feat(auth): add JWT Bearer authentication for external API clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,16 @@ POSTGRES_DB=scouter
 POSTGRES_USER=scouter
 POSTGRES_PASSWORD=CHANGEME_STRONG_PASSWORD
 
+# JWT / API token authentication
+# REQUIRED for Bearer token auth (used by external clients like n8n, scripts, etc.)
+# Generate a strong secret (≥ 32 chars):
+#   php -r "echo bin2hex(random_bytes(48)) . PHP_EOL;"
+JWT_SECRET=CHANGEME_GENERATE_A_64_CHAR_HEX_SECRET_WITH_OPENSSL_OR_PHP
+JWT_ISSUER=scouter
+# Access token lifetime in seconds (default 900 = 15 minutes)
+JWT_ACCESS_TTL=900
+# Refresh token lifetime in seconds (default 2592000 = 30 days)
+JWT_REFRESH_TTL=2592000
+
 # Instructions PRODUCTION:
 # Configurer ces variables d'environnement directement sur votre serveur

--- a/app/Auth/Auth.php
+++ b/app/Auth/Auth.php
@@ -2,6 +2,7 @@
 
 namespace App\Auth;
 
+use App\Auth\JwtService;
 use App\Database\UserRepository;
 use App\Database\ProjectRepository;
 use App\Database\CrawlRepository;
@@ -610,7 +611,94 @@ class Auth
     {
         if (!$this->isLoggedIn()) {
             http_response_code(401);
+            header('WWW-Authenticate: Bearer realm="scouter-api"');
             die(json_encode(['error' => 'Non authentifié']));
         }
+    }
+
+    // ==================== BEARER TOKEN AUTHENTICATION ====================
+
+    /**
+     * Tente d'authentifier la requête via un JWT Bearer (header Authorization).
+     *
+     * Si un access token valide est présent, hydrate l'état de session en mémoire
+     * pour que tout le code existant (requireLoginApi, isAdmin, canAccessProject,
+     * etc.) continue de fonctionner sans modification.
+     *
+     * N'écrase pas une session déjà authentifiée.
+     *
+     * @return bool true si l'authentification Bearer a réussi
+     */
+    public function authenticateFromBearer(): bool
+    {
+        if ($this->isLoggedIn()) {
+            return false;
+        }
+
+        $header = $this->getAuthorizationHeader();
+        if ($header === null || stripos($header, 'Bearer ') !== 0) {
+            return false;
+        }
+
+        $token = trim(substr($header, 7));
+        if ($token === '') {
+            return false;
+        }
+
+        try {
+            $jwt = new JwtService();
+            $decoded = $jwt->decode($token);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        if (($decoded->type ?? null) !== 'access') {
+            return false;
+        }
+
+        $userId = isset($decoded->sub) ? (int) $decoded->sub : 0;
+        if ($userId <= 0) {
+            return false;
+        }
+
+        // Vérifie que l'utilisateur existe toujours (révocation par suppression)
+        $user = $this->users ? $this->users->getById($userId) : null;
+        if (!$user) {
+            return false;
+        }
+
+        // Hydrate l'état de session (non persisté — regenère pas le cookie)
+        $_SESSION['user_id']   = $user->id;
+        $_SESSION['email']     = $user->email;
+        $_SESSION['role']      = $user->role ?? 'user';
+        $_SESSION['logged_in'] = true;
+        $_SESSION['auth_via']  = 'bearer';
+
+        return true;
+    }
+
+    /**
+     * Lit le header Authorization en couvrant les différentes configurations
+     * de serveur (Apache, Nginx+FPM, CGI/Redirect).
+     */
+    private function getAuthorizationHeader(): ?string
+    {
+        if (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
+            return $_SERVER['HTTP_AUTHORIZATION'];
+        }
+        if (!empty($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+            return $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+        }
+        if (function_exists('apache_request_headers')) {
+            $headers = apache_request_headers();
+            if ($headers) {
+                foreach ($headers as $name => $value) {
+                    if (strcasecmp($name, 'Authorization') === 0) {
+                        return $value;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }

--- a/app/Auth/JwtService.php
+++ b/app/Auth/JwtService.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Auth;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+/**
+ * Encodage/décodage des JSON Web Tokens (JWT)
+ *
+ * Implémente l'authentification stateless via tokens signés HS256 avec :
+ *  - Algorithme figé (protection contre l'attaque alg=none)
+ *  - Claims standards (iss, aud, iat, nbf, exp, jti, sub)
+ *  - Vérification stricte de l'émetteur et de l'audience
+ *  - Paires access-token court / refresh-token long
+ *
+ * Config via variables d'environnement :
+ *  - JWT_SECRET       (≥ 32 caractères, OBLIGATOIRE)
+ *  - JWT_ISSUER       (défaut: "scouter")
+ *  - JWT_ACCESS_TTL   (secondes, défaut 900 = 15 min)
+ *  - JWT_REFRESH_TTL  (secondes, défaut 2592000 = 30 jours)
+ *
+ * @package    Scouter
+ * @subpackage Auth
+ */
+class JwtService
+{
+    private const ALGORITHM = 'HS256';
+    private const MIN_SECRET_LENGTH = 32;
+
+    private string $secret;
+    private string $issuer;
+    private int $accessTtl;
+    private int $refreshTtl;
+
+    public function __construct()
+    {
+        $secret = (string) (getenv('JWT_SECRET') ?: ($_ENV['JWT_SECRET'] ?? ''));
+        if (strlen($secret) < self::MIN_SECRET_LENGTH) {
+            throw new \RuntimeException(
+                'JWT_SECRET must be defined and at least ' . self::MIN_SECRET_LENGTH . ' characters long'
+            );
+        }
+        $this->secret = $secret;
+        $this->issuer = (string) (getenv('JWT_ISSUER') ?: ($_ENV['JWT_ISSUER'] ?? 'scouter'));
+        $this->accessTtl = (int) (getenv('JWT_ACCESS_TTL') ?: ($_ENV['JWT_ACCESS_TTL'] ?? 900));
+        $this->refreshTtl = (int) (getenv('JWT_REFRESH_TTL') ?: ($_ENV['JWT_REFRESH_TTL'] ?? 2592000));
+
+        if ($this->accessTtl < 60 || $this->refreshTtl < $this->accessTtl) {
+            throw new \RuntimeException('Invalid JWT TTL configuration');
+        }
+    }
+
+    /**
+     * Émet un access token de courte durée.
+     *
+     * @return array{token:string,expires_in:int,jti:string,expires_at:int}
+     */
+    public function issueAccessToken(int $userId, string $email, string $role): array
+    {
+        return $this->issueToken('access', $userId, $this->accessTtl, [
+            'email' => $email,
+            'role'  => $role,
+        ]);
+    }
+
+    /**
+     * Émet un refresh token de longue durée.
+     *
+     * @return array{token:string,expires_in:int,jti:string,expires_at:int}
+     */
+    public function issueRefreshToken(int $userId): array
+    {
+        return $this->issueToken('refresh', $userId, $this->refreshTtl);
+    }
+
+    /**
+     * Décode un JWT en validant signature, issuer, audience, exp et nbf.
+     *
+     * @throws \Throwable si le token est invalide / expiré
+     */
+    public function decode(string $token): object
+    {
+        $decoded = JWT::decode($token, new Key($this->secret, self::ALGORITHM));
+
+        if (!isset($decoded->iss) || !hash_equals($this->issuer, (string) $decoded->iss)) {
+            throw new \UnexpectedValueException('Invalid issuer');
+        }
+        if (!isset($decoded->aud) || !hash_equals($this->issuer, (string) $decoded->aud)) {
+            throw new \UnexpectedValueException('Invalid audience');
+        }
+        if (!isset($decoded->type) || !in_array($decoded->type, ['access', 'refresh'], true)) {
+            throw new \UnexpectedValueException('Invalid token type');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Hash SHA-256 pour stockage en base (on ne stocke jamais le token en clair).
+     */
+    public function hashToken(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+
+    public function getAccessTtl(): int
+    {
+        return $this->accessTtl;
+    }
+
+    public function getRefreshTtl(): int
+    {
+        return $this->refreshTtl;
+    }
+
+    /**
+     * @return array{token:string,expires_in:int,jti:string,expires_at:int}
+     */
+    private function issueToken(string $type, int $userId, int $ttl, array $extra = []): array
+    {
+        $now = time();
+        $jti = bin2hex(random_bytes(16));
+        $exp = $now + $ttl;
+
+        $payload = array_merge([
+            'iss'  => $this->issuer,
+            'aud'  => $this->issuer,
+            'iat'  => $now,
+            'nbf'  => $now,
+            'exp'  => $exp,
+            'jti'  => $jti,
+            'sub'  => (string) $userId,
+            'type' => $type,
+        ], $extra);
+
+        $token = JWT::encode($payload, $this->secret, self::ALGORITHM);
+
+        return [
+            'token'      => $token,
+            'expires_in' => $ttl,
+            'jti'        => $jti,
+            'expires_at' => $exp,
+        ];
+    }
+}

--- a/app/Auth/TokenRepository.php
+++ b/app/Auth/TokenRepository.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Auth;
+
+use App\Database\PostgresDatabase;
+use PDO;
+
+/**
+ * Repository des refresh tokens et des tentatives d'authentification
+ *
+ * Gère la persistance des refresh tokens (hashés) pour permettre la révocation
+ * et la rotation, ainsi que le log des tentatives de login pour le rate-limiting.
+ *
+ * @package    Scouter
+ * @subpackage Auth
+ */
+class TokenRepository
+{
+    private PDO $db;
+
+    public function __construct(?PDO $db = null)
+    {
+        $this->db = $db ?? PostgresDatabase::getInstance()->getConnection();
+    }
+
+    /**
+     * Enregistre un nouveau refresh token (hashé).
+     */
+    public function storeRefresh(
+        int $userId,
+        string $jti,
+        string $tokenHash,
+        int $expiresAt,
+        ?string $userAgent,
+        ?string $ip
+    ): void {
+        $stmt = $this->db->prepare("
+            INSERT INTO api_refresh_tokens (user_id, jti, token_hash, expires_at, user_agent, ip_address)
+            VALUES (:user_id, :jti, :token_hash, to_timestamp(:expires_at), :user_agent, :ip_address)
+        ");
+        $stmt->execute([
+            ':user_id'    => $userId,
+            ':jti'        => $jti,
+            ':token_hash' => $tokenHash,
+            ':expires_at' => $expiresAt,
+            ':user_agent' => $userAgent,
+            ':ip_address' => $ip,
+        ]);
+    }
+
+    /**
+     * Retourne un refresh token actif (non révoqué, non expiré) par son JTI.
+     */
+    public function findActiveByJti(string $jti): ?object
+    {
+        $stmt = $this->db->prepare("
+            SELECT * FROM api_refresh_tokens
+            WHERE jti = :jti AND revoked_at IS NULL AND expires_at > NOW()
+        ");
+        $stmt->execute([':jti' => $jti]);
+        return $stmt->fetch(PDO::FETCH_OBJ) ?: null;
+    }
+
+    /**
+     * Révoque un refresh token par son JTI et enregistre son remplaçant (rotation).
+     */
+    public function rotate(string $oldJti, string $newJti): void
+    {
+        $stmt = $this->db->prepare("
+            UPDATE api_refresh_tokens
+            SET revoked_at = NOW(), replaced_by_jti = :new_jti, last_used_at = NOW()
+            WHERE jti = :old_jti AND revoked_at IS NULL
+        ");
+        $stmt->execute([':old_jti' => $oldJti, ':new_jti' => $newJti]);
+    }
+
+    /**
+     * Révoque un refresh token (idempotent).
+     */
+    public function revoke(string $jti): void
+    {
+        $stmt = $this->db->prepare("
+            UPDATE api_refresh_tokens SET revoked_at = NOW()
+            WHERE jti = :jti AND revoked_at IS NULL
+        ");
+        $stmt->execute([':jti' => $jti]);
+    }
+
+    /**
+     * Révoque tous les refresh tokens actifs d'un utilisateur.
+     * Utile en cas de suspicion de compromission (ex: réutilisation d'un refresh token).
+     */
+    public function revokeAllForUser(int $userId): void
+    {
+        $stmt = $this->db->prepare("
+            UPDATE api_refresh_tokens SET revoked_at = NOW()
+            WHERE user_id = :user_id AND revoked_at IS NULL
+        ");
+        $stmt->execute([':user_id' => $userId]);
+    }
+
+    /**
+     * Supprime les tokens expirés depuis plus de 7 jours (à appeler depuis un cron).
+     */
+    public function purgeExpired(): int
+    {
+        return (int) $this->db->exec(
+            "DELETE FROM api_refresh_tokens WHERE expires_at < NOW() - INTERVAL '7 days'"
+        );
+    }
+
+    // ==================== Rate-limit (tentatives de login) ====================
+
+    public function recordAuthAttempt(string $identifier, bool $success, ?string $ip): void
+    {
+        $stmt = $this->db->prepare("
+            INSERT INTO api_auth_attempts (identifier, success, ip_address)
+            VALUES (:identifier, :success, :ip)
+        ");
+        $stmt->execute([
+            ':identifier' => $identifier,
+            ':success'    => $success ? 't' : 'f',
+            ':ip'         => $ip,
+        ]);
+    }
+
+    /**
+     * Compte les échecs de login récents pour un identifiant (email) donné.
+     */
+    public function countRecentFailures(string $identifier, int $windowSeconds): int
+    {
+        $stmt = $this->db->prepare("
+            SELECT COUNT(*) AS c FROM api_auth_attempts
+            WHERE identifier = :identifier
+              AND success = FALSE
+              AND attempted_at > NOW() - make_interval(secs => :window)
+        ");
+        $stmt->execute([
+            ':identifier' => $identifier,
+            ':window'     => $windowSeconds,
+        ]);
+        $row = $stmt->fetch(PDO::FETCH_OBJ);
+        return $row ? (int) $row->c : 0;
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Auth\Auth;
+use App\Auth\JwtService;
+use App\Auth\TokenRepository;
+use App\Database\UserRepository;
+use App\Http\Controller;
+use App\Http\Request;
+use App\Http\Response;
+
+/**
+ * Controller d'authentification par JWT Bearer (API externe, n8n, scripts…)
+ *
+ * Endpoints :
+ *  - POST /auth/token    → échange email/password contre access + refresh token
+ *  - POST /auth/refresh  → échange un refresh token contre une nouvelle paire (rotation)
+ *  - POST /auth/revoke   → révoque un refresh token (logout côté API)
+ *
+ * Sécurité :
+ *  - Rate-limit sur /auth/token (5 échecs par email / 15 min → 429)
+ *  - Messages d'erreur génériques (pas d'énumération d'utilisateurs)
+ *  - Refresh tokens hashés en base, rotation à chaque usage, révocation de toute
+ *    la famille de tokens en cas de détection de réutilisation
+ *
+ * @package    Scouter
+ * @subpackage Http\Controllers
+ */
+class AuthController extends Controller
+{
+    private const MAX_FAILURES = 5;
+    private const FAILURE_WINDOW_SEC = 900; // 15 min
+
+    private JwtService $jwt;
+    private TokenRepository $tokens;
+    private UserRepository $users;
+
+    public function __construct(Auth $auth)
+    {
+        parent::__construct($auth);
+        $this->jwt    = new JwtService();
+        $this->tokens = new TokenRepository();
+        $this->users  = new UserRepository();
+    }
+
+    /**
+     * POST /auth/token
+     * Body: { "email": "...", "password": "..." }
+     * → { access_token, refresh_token, token_type, expires_in, refresh_expires_in }
+     */
+    public function token(Request $request): void
+    {
+        $email    = trim((string) $request->get('email', ''));
+        $password = (string) $request->get('password', '');
+
+        if ($email === '' || $password === '') {
+            $this->error('Email et mot de passe requis', 400);
+            return;
+        }
+
+        $identifier = strtolower($email);
+        $ip = $this->clientIp();
+
+        if ($this->tokens->countRecentFailures($identifier, self::FAILURE_WINDOW_SEC) >= self::MAX_FAILURES) {
+            Response::json(
+                ['success' => false, 'error' => 'Trop de tentatives, réessayez plus tard'],
+                429
+            );
+            return;
+        }
+
+        $user = $this->users->getByEmail($email);
+        if (!$user || !password_verify($password, $user->password_hash)) {
+            $this->tokens->recordAuthAttempt($identifier, false, $ip);
+            $this->error('Identifiants invalides', 401);
+            return;
+        }
+
+        $this->tokens->recordAuthAttempt($identifier, true, $ip);
+
+        $this->issueTokenPair(
+            (int) $user->id,
+            (string) $user->email,
+            (string) ($user->role ?? 'user'),
+            $this->userAgent(),
+            $ip
+        );
+    }
+
+    /**
+     * POST /auth/refresh
+     * Body: { "refresh_token": "..." }
+     */
+    public function refresh(Request $request): void
+    {
+        $refreshToken = (string) $request->get('refresh_token', '');
+        if ($refreshToken === '') {
+            $this->error('refresh_token requis', 400);
+            return;
+        }
+
+        try {
+            $decoded = $this->jwt->decode($refreshToken);
+        } catch (\Throwable $e) {
+            $this->error('Refresh token invalide', 401);
+            return;
+        }
+
+        if (($decoded->type ?? null) !== 'refresh') {
+            $this->error('Type de token invalide', 401);
+            return;
+        }
+
+        $jti = (string) ($decoded->jti ?? '');
+        $userId = (int) ($decoded->sub ?? 0);
+        if ($jti === '' || $userId <= 0) {
+            $this->error('Refresh token invalide', 401);
+            return;
+        }
+
+        $stored = $this->tokens->findActiveByJti($jti);
+        if (!$stored) {
+            // JTI inconnu ou déjà consommé → suspicion de réutilisation.
+            // Par précaution, on révoque toute la famille de tokens de l'utilisateur.
+            $this->tokens->revokeAllForUser($userId);
+            $this->error('Refresh token révoqué', 401);
+            return;
+        }
+
+        if (!hash_equals($stored->token_hash, $this->jwt->hashToken($refreshToken))) {
+            $this->error('Refresh token invalide', 401);
+            return;
+        }
+
+        $user = $this->users->getById($userId);
+        if (!$user) {
+            $this->error('Utilisateur introuvable', 401);
+            return;
+        }
+
+        // Rotation : on émet une nouvelle paire et on révoque l'ancien refresh.
+        $access = $this->jwt->issueAccessToken(
+            (int) $user->id,
+            (string) $user->email,
+            (string) ($user->role ?? 'user')
+        );
+        $newRefresh = $this->jwt->issueRefreshToken((int) $user->id);
+
+        $this->tokens->storeRefresh(
+            (int) $user->id,
+            $newRefresh['jti'],
+            $this->jwt->hashToken($newRefresh['token']),
+            $newRefresh['expires_at'],
+            $this->userAgent(),
+            $this->clientIp()
+        );
+        $this->tokens->rotate($jti, $newRefresh['jti']);
+
+        Response::json([
+            'access_token'       => $access['token'],
+            'token_type'         => 'Bearer',
+            'expires_in'         => $access['expires_in'],
+            'refresh_token'      => $newRefresh['token'],
+            'refresh_expires_in' => $newRefresh['expires_in'],
+        ]);
+    }
+
+    /**
+     * POST /auth/revoke
+     * Body: { "refresh_token": "..." }
+     * Idempotent — répond toujours 200 pour éviter de fuiter l'existence du JTI.
+     */
+    public function revoke(Request $request): void
+    {
+        $refreshToken = (string) $request->get('refresh_token', '');
+        if ($refreshToken !== '') {
+            try {
+                $decoded = $this->jwt->decode($refreshToken);
+                if (($decoded->type ?? null) === 'refresh' && isset($decoded->jti)) {
+                    $this->tokens->revoke((string) $decoded->jti);
+                }
+            } catch (\Throwable $e) {
+                // idempotent — on ignore les erreurs de décodage
+            }
+        }
+        $this->success([], 'Token révoqué');
+    }
+
+    private function issueTokenPair(
+        int $userId,
+        string $email,
+        string $role,
+        ?string $userAgent,
+        ?string $ip
+    ): void {
+        $access = $this->jwt->issueAccessToken($userId, $email, $role);
+        $refresh = $this->jwt->issueRefreshToken($userId);
+
+        $this->tokens->storeRefresh(
+            $userId,
+            $refresh['jti'],
+            $this->jwt->hashToken($refresh['token']),
+            $refresh['expires_at'],
+            $userAgent,
+            $ip
+        );
+
+        Response::json([
+            'access_token'       => $access['token'],
+            'token_type'         => 'Bearer',
+            'expires_in'         => $access['expires_in'],
+            'refresh_token'      => $refresh['token'],
+            'refresh_expires_in' => $refresh['expires_in'],
+        ]);
+    }
+
+    private function clientIp(): ?string
+    {
+        return $_SERVER['REMOTE_ADDR'] ?? null;
+    }
+
+    private function userAgent(): ?string
+    {
+        $ua = $_SERVER['HTTP_USER_AGENT'] ?? null;
+        return $ua !== null ? substr($ua, 0, 500) : null;
+    }
+}

--- a/app/Http/Router.php
+++ b/app/Http/Router.php
@@ -193,6 +193,9 @@ class Router
     private function applyAuth(array $options): void
     {
         if (!empty($options['auth'])) {
+            // Essaie d'abord l'auth JWT Bearer (clients API externes, n8n...),
+            // puis retombe sur l'auth session classique si aucun token n'est fourni.
+            $this->auth->authenticateFromBearer();
             $this->auth->requireLoginApi();
         }
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
         "chuyskywalker/rolling-curl": "^3.1",
         "xparse/element-finder": "^3.0",
         "mustangostang/spyc": "^0.6.2",
-        "fivefilters/readability.php": "^3.3"
+        "fivefilters/readability.php": "^3.3",
+        "firebase/php-jwt": "^6.10"
     },
     "autoload": {
         "psr-4": {

--- a/migrations/2026-04-24-00-00-api-tokens.php
+++ b/migrations/2026-04-24-00-00-api-tokens.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Migration: API token authentication (JWT Bearer)
+ *
+ * Creates:
+ *  - api_refresh_tokens : stores hashed refresh tokens for revocation/rotation
+ *  - api_auth_attempts  : records login attempts for rate-limiting
+ */
+
+use App\Database\PostgresDatabase;
+
+$pdo = PostgresDatabase::getInstance()->getConnection();
+
+try {
+    // =============================================
+    // api_refresh_tokens
+    // =============================================
+    $stmt = $pdo->query("
+        SELECT table_name FROM information_schema.tables
+        WHERE table_name = 'api_refresh_tokens'
+    ");
+
+    if ($stmt->fetch()) {
+        echo "   → Table api_refresh_tokens already exists, skipping\n";
+    } else {
+        echo "   → Creating api_refresh_tokens table... ";
+        $pdo->exec("
+            CREATE TABLE api_refresh_tokens (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                jti VARCHAR(64) NOT NULL UNIQUE,
+                token_hash VARCHAR(128) NOT NULL,
+                expires_at TIMESTAMP NOT NULL,
+                revoked_at TIMESTAMP DEFAULT NULL,
+                replaced_by_jti VARCHAR(64) DEFAULT NULL,
+                user_agent TEXT DEFAULT NULL,
+                ip_address VARCHAR(45) DEFAULT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_used_at TIMESTAMP DEFAULT NULL
+            )
+        ");
+        $pdo->exec("CREATE INDEX idx_api_refresh_tokens_user ON api_refresh_tokens(user_id)");
+        $pdo->exec("CREATE INDEX idx_api_refresh_tokens_active ON api_refresh_tokens(jti) WHERE revoked_at IS NULL");
+        echo "OK\n";
+    }
+
+    // =============================================
+    // api_auth_attempts (rate-limit)
+    // =============================================
+    $stmt = $pdo->query("
+        SELECT table_name FROM information_schema.tables
+        WHERE table_name = 'api_auth_attempts'
+    ");
+
+    if ($stmt->fetch()) {
+        echo "   → Table api_auth_attempts already exists, skipping\n";
+    } else {
+        echo "   → Creating api_auth_attempts table... ";
+        $pdo->exec("
+            CREATE TABLE api_auth_attempts (
+                id SERIAL PRIMARY KEY,
+                identifier VARCHAR(255) NOT NULL,
+                success BOOLEAN NOT NULL DEFAULT FALSE,
+                ip_address VARCHAR(45) DEFAULT NULL,
+                attempted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ");
+        $pdo->exec("CREATE INDEX idx_api_auth_attempts_identifier ON api_auth_attempts(identifier, attempted_at)");
+        echo "OK\n";
+    }
+
+    echo "   ✓ Migration completed successfully\n";
+    return true;
+
+} catch (Exception $e) {
+    echo "\n   ✗ Error: " . $e->getMessage() . "\n";
+    return false;
+}

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -28,11 +28,21 @@ use App\Http\Controllers\QueryController;
 use App\Http\Controllers\ExportController;
 use App\Http\Controllers\MonitorController;
 use App\Http\Controllers\CategorizationController;
+use App\Http\Controllers\AuthController;
 
 $request = new Request();
 
 try {
     $router = new Router();
+
+    // =============================================================================
+    // AUTH — JWT Bearer (clients API externes: n8n, scripts, CI, …)
+    // Ces endpoints sont publics (pas de middleware auth) : le login/refresh
+    // constitue précisément l'obtention du token.
+    // =============================================================================
+    $router->post('/auth/token', [AuthController::class, 'token']);
+    $router->post('/auth/refresh', [AuthController::class, 'refresh']);
+    $router->post('/auth/revoke', [AuthController::class, 'revoke']);
 
     // =============================================================================
     // CATEGORIES


### PR DESCRIPTION
Enables programmatic access to the Scouter REST API from external tools (n8n, CI jobs, scripts) alongside the existing session-based auth used by the web UI. Both authentication modes now coexist on every protected route.

## Why

All API endpoints are currently protected by PHP-session auth only, which makes them unusable from headless clients that can't maintain cookies across redirects or share a session with a browser. Adding JWT Bearer support unlocks standard HTTP client usage (Authorization: Bearer <token>) without touching any of the existing controllers or permission checks.

## How

A new `App\Auth\JwtService` issues and validates signed JWTs (HS256) and a new `App\Auth\TokenRepository` persists hashed refresh tokens for revocation and rotation. The existing `Auth` class gets an `authenticateFromBearer()` method that reads the Authorization header, verifies the token and hydrates the same session state that a UI login would produce — so every existing role/ownership check (`isAdmin`, `canAccessProject`, `canManageCrawl`, …) keeps working unchanged. The router attempts Bearer auth before falling back to session auth on any route flagged `['auth' => true]`.

Three new public endpoints are exposed:

  POST /api/auth/token    email/password → { access_token, refresh_token }
  POST /api/auth/refresh  refresh_token  → rotated { access, refresh } pair
  POST /api/auth/revoke   refresh_token  → revoke (logout)

## Security model (standard practice)

- Algorithm pinned to HS256 — no `alg=none` downgrade
- JWT_SECRET enforced ≥ 32 characters at boot, loaded from env only
- Short-lived access token (default 15 min) + long-lived refresh (30 d)
- Refresh tokens stored as SHA-256 hashes, never in plaintext
- Refresh token rotation on every use; reuse of a consumed token triggers revocation of the entire token family for that user (replay protection)
- Strict claim validation: iss, aud, exp, nbf, type (access vs refresh)
- Rate limiting on /auth/token: 5 failed attempts per email / 15 min → 429
- Generic error messages (no user enumeration)
- `hash_equals` for all sensitive comparisons
- `WWW-Authenticate: Bearer` header on 401 responses

## Changes

New files:
- app/Auth/JwtService.php            JWT encode/decode + strict validation
- app/Auth/TokenRepository.php       Hashed refresh tokens + attempt log
- app/Http/Controllers/AuthController.php   /auth/{token,refresh,revoke}
- migrations/2026-04-24-00-00-api-tokens.php
    tables `api_refresh_tokens` and `api_auth_attempts`

Modified files:
- composer.json                Add `firebase/php-jwt ^6.10`
- .env.example                 Document JWT_SECRET / JWT_ISSUER / TTLs
- app/Auth/Auth.php            `authenticateFromBearer()` + WWW-Authenticate
- app/Http/Router.php          Try Bearer before session in `applyAuth()`
- web/api/index.php            Register the three new public auth routes

## Deployment

1. `composer install` (or rebuild the PHP image) to pull firebase/php-jwt
2. Run migrations: `php migrations/migrate.php`
3. Set a strong secret in the production env: `php -r "echo bin2hex(random_bytes(48)) . PHP_EOL;"` and export it as `JWT_SECRET` (plus optional `JWT_ISSUER`, `JWT_ACCESS_TTL`, `JWT_REFRESH_TTL`).

No existing route behavior changes; session-authenticated browsers keep working exactly as before.