### PR TITLE
Fix: prevent crawler crash on pages with HTML comments (Readability TypeError)

### DIFF
--- a/app/Core/Page.php
+++ b/app/Core/Page.php
@@ -463,34 +463,34 @@ class Page
             $configuration->setSubstituteEntities(false);
             
             // Parser avec Readability
+            // Strip HTML comments: readability.php v3.3.3 crashes (TypeError) on DOMComment nodes
+            $htmlForReadability = preg_replace('/<!--.*?-->/s', '', $this->dom);
             $readability = new Readability($configuration);
-            $readability->parse($this->dom);
-            
+            $readability->parse($htmlForReadability);
+
             // Récupérer le contenu texte
             $content = $readability->getContent();
             if (empty($content)) {
                 return 0;
             }
-            
+
             // Nettoyer le HTML pour ne garder que le texte
             $text = strip_tags($content);
             $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-            
+
             // Nettoyer les espaces multiples et compter les mots
             $text = preg_replace('/\s+/', ' ', trim($text));
-            
+
             if (empty($text)) {
                 return 0;
             }
-            
+
             // Compter les mots
             $wordCount = str_word_count($text, 0);
-            
+
             return $wordCount > 0 ? $wordCount : 0;
-            
-        } catch (ParseException $e) {
-            return 0;
-        } catch (\Exception $e) {
+
+        } catch (\Throwable $e) {
             return 0;
         }
     }
@@ -847,8 +847,10 @@ class Page
             $configuration->setFixRelativeURLs(false);
             $configuration->setSubstituteEntities(false);
 
+            // Strip HTML comments: readability.php v3.3.3 crashes (TypeError) on DOMComment nodes
+            $htmlForReadability = preg_replace('/<!--.*?-->/s', '', $this->dom);
             $readability = new Readability($configuration);
-            $readability->parse($this->dom);
+            $readability->parse($htmlForReadability);
             $readabilityContent = $readability->getContent();
 
             if (!empty($readabilityContent)) {
@@ -860,7 +862,7 @@ class Page
                     $useReadability = true;
                 }
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $content = null;
         }
 


### PR DESCRIPTION
  ## Summary

  Fixes #20 — the crawler was aborting mid-run on certain sites (e.g. `golighter.de`) with a fatal `TypeError` coming from the `fivefilters/readability.php` library:

  ```
  ERROR: fivefilters\Readability\Readability::_cleanStyles(): Argument #1 ($node)
  must be of type DOMDocument|DOMNode|DOMElement|DOMText|DOMProcessingInstruction|DOMCdataSection,
  DOMComment given, called in /app/vendor/fivefilters/readability.php/src/Readability.php on line 1782
  ```

  ## Root cause

  In `fivefilters/readability.php` v3.3.3, `_cleanStyles()` is a recursive method (`Readability.php:1759`) that walks every `firstChild` / `nextSibling` of a node. Its type union
  explicitly lists `DOMDocument|DOMNode|DOMElement|DOMText|DOMProcessingInstruction|DOMCdataSection` — but **omits `DOMComment`**. The library uses its own DOM classes under
  `fivefilters\Readability\Nodes\DOM\*`, so PHP does not treat the native `DOMComment` as a subtype of the listed `DOMNode` and throws a `TypeError` as soon as the recursion hits an HTML
  comment node.

  This is a fatal `\Error`, not an `\Exception`, so the existing `catch (\Exception $e)` in `Page::computeSimhash()` did not catch it, and `Page::calculateWordCount()` only caught
  `ParseException` and `\Exception` as well — both let the `TypeError` escape and kill the worker.

  `golighter.de` triggers it because it embeds HTML comments (analytics blocks, conditional markup) in locations Readability traverses. Most other sites we'd previously crawled either had
   no such comments or had them stripped earlier in the pipeline.

  ## Fix

  In `app/Core/Page.php`, at both Readability call sites (`calculateWordCount`, `computeSimhash`):

  1. **Strip HTML comments before parsing.** `preg_replace('/<!--.*?-->/s', '', $this->dom)` is run on the HTML string fed to `$readability->parse()`. Comments carry no value for
  main-content extraction, so this avoids the buggy code path entirely.
  2. **Widen the catch to `\Throwable`.** Any future type-related crash from the same library (or any other unforeseen `\Error`) is now caught and the page degrades gracefully (word_count
   = 0, simhash falls back to its non-Readability path) instead of killing the crawl.