### PR TITLE
fix: prevent post-processing failures from marking crawl as failed

### DIFF
--- a/app/Analysis/PostProcessor.php
+++ b/app/Analysis/PostProcessor.php
@@ -794,6 +794,29 @@ class PostProcessor
      */
     public function sitemapAnalysis(): void
     {
+        // Sitemap orphan analysis only makes sense on a crawl that has run to
+        // its natural end. If the crawl was STOPPED by the user (and is
+        // therefore resumable), running it now would insert every sitemap URL
+        // as an `in_crawl=FALSE` placeholder row. On resume those rows shadow
+        // the real links discovered by the spider (insertPages uses
+        // `ON CONFLICT (crawl_id, id) DO NOTHING`), so the links never get
+        // promoted into the frontier and the walk dies — crawling nothing.
+        // Defer to the final post-processing pass that runs when the crawl
+        // truly completes (status becomes 'finished'). Any non-completed
+        // status is skipped : 'stopped'/'stopping' (user stop, resumable),
+        // 'error' (crashed — e.g. crawl 558 left 598 sitemap rows stuck at
+        // code 0 because fetchSitemapOnlyPages never finished), 'failed'
+        // (watchdog kill). Only a clean finish ('running'/'processing' at
+        // this point) proceeds.
+        $stmt = $this->db->prepare("SELECT status FROM crawls WHERE id = :id");
+        $stmt->execute([':id' => $this->crawlId]);
+        $crawlStatus = (string)$stmt->fetchColumn();
+        if (in_array($crawlStatus, ['stopping', 'stopped', 'failed', 'error'], true)) {
+            echo "\r \033[32m Sitemap analysis \033[0m : \033[33mdeferred (crawl not finished — will run on completion)\033[0m                    \n";
+            flush();
+            return;
+        }
+
         // Load crawl config
         $stmt = $this->db->prepare("SELECT config, domain FROM crawls WHERE id = :id");
         $stmt->execute([':id' => $this->crawlId]);

--- a/app/Analysis/PostProcessor.php
+++ b/app/Analysis/PostProcessor.php
@@ -84,7 +84,8 @@ class PostProcessor
                     // Log to stderr so worker captures it in log file
                     fwrite(STDERR, "ERROR in PostProcessor::$step(): " . $e->getMessage()
                         . " in " . $e->getFile() . ":" . $e->getLine() . "\n");
-                    throw $e;
+                    // Best-effort : une étape qui plante ne doit jamais faire passer
+                    // le crawl entier en 'failed'. On log et on continue.
                 }
             }
         } finally {
@@ -1006,6 +1007,7 @@ class PostProcessor
             'regexExtractors'      => $advanced['regexExtractors'] ?? [],
             'skip_link_extraction' => true, // ← THE flag: PageCrawler will skip storeLinks/storeRedirect
             'silent_progress'      => true, // ← keep the sitemap step on a single log line
+            'skip_stop_signal'     => true, // ← post-processing: ignorer les changements de status sur la table crawls
         ];
 
         $crawlDb = new \App\Database\CrawlDatabase($this->crawlId, $runtimeConfig);

--- a/app/Core/DepthCrawler.php
+++ b/app/Core/DepthCrawler.php
@@ -213,10 +213,17 @@ class DepthCrawler
     
     private function checkStopSignal()
     {
+        // Pendant le post-processing, le crawl principal est déjà fini : un
+        // changement de status sur la table crawls (stop utilisateur, watchdog,
+        // worker qui redémarre) ne doit pas tuer une étape de finalisation.
+        if (!empty($this->config['skip_stop_signal'])) {
+            return;
+        }
+
         // Vérifier toutes les 3 mises à jour OU toutes les 5 secondes
         $now = time();
         $shouldCheck = ($this->update % 3 === 0) || ($now - $this->lastStopCheck >= 5);
-        
+
         if ($shouldCheck) {
             $this->lastStopCheck = $now;
             $status = $this->crawlDb->getCrawlStatus();

--- a/tests/Unit/SitemapLogFormatTest.php
+++ b/tests/Unit/SitemapLogFormatTest.php
@@ -57,13 +57,15 @@ describe('Sitemap log format', function () {
         preg_match_all('/echo\s+"\\\\r[^"]*Sitemap analysis[^"]*\\\\n"/', $rest, $matches);
 
         // Each line ending in \n must be either the final summary or a terminal status
-        // (skipped / no URLs found). Acceptable markers in the source:
+        // (skipped / no URLs found / deferred). Acceptable markers in the source:
         //  - "skipped"        → caught exception path
         //  - "no URLs found"  → empty sitemap result
+        //  - "deferred"       → crawl not finished (stopped/error/failed) → early return
         //  - "$summary"       → final tally interpolation
         foreach ($matches[0] as $line) {
             $isFinal = strpos($line, 'skipped') !== false
                     || strpos($line, 'no URLs found') !== false
+                    || strpos($line, 'deferred') !== false
                     || strpos($line, '$summary') !== false;
             expect($isFinal)->toBeTrue();
         }


### PR DESCRIPTION
## Context

On a large staging crawl, the job was flipping to `failed` even though the main crawl had finished successfully. Typical log signature:

```
✓ 7 URLs resolved on attempt 1
✗ Post-processing error in sitemapAnalysis: Crawl stop signal received
ERROR in PostProcessor::sitemapAnalysis(): Crawl stop signal received in /app/app/Core/DepthCrawler.php:224
ERROR: Crawl stop signal received
```

## Root cause

Exception chain introduced alongside the new sitemap feature, but the real culprit is `PostProcessor::run()` itself — a post-processing step should never be able to fail the whole crawl.

1. `sitemapAnalysis()` spins up a fresh `DepthCrawler` to fetch the sitemap-only URLs (`PostProcessor.php:1012`).
2. That `DepthCrawler` calls `checkStopSignal()`, which throws as soon as `crawls.status` is `stopping` / `stopped` / `failed` (`DepthCrawler.php:223`). That signal is meant to interrupt the main crawl loop, not a finalisation step.
3. `PostProcessor::run()` re-throws the exception (`PostProcessor.php:87`) → it bubbles up through `Crawler::depthStarter()` → `scouter.php` catches `Throwable` and marks the job as `failed`.

Any external mutation of `crawls.status` during post-processing triggers this path: user stop, a worker restart cycling jobs, watchdog timeout, etc. The main crawl is already done at this point — the failure is purely cosmetic but very visible.

## Fix

- **`PostProcessor::run()`** — best-effort step execution. A failing step is logged to stderr but is no longer re-thrown, so the rest of the post-processing chain (and the job state) keep moving forward.
- **`PostProcessor::fetchSitemapOnlyPages()`** — pass a new `skip_stop_signal => true` flag in the runtime config of the internal `DepthCrawler`.
- **`DepthCrawler::checkStopSignal()`** — honor `skip_stop_signal` and return early. The stop signal mechanism is for the main crawl loop, not for post-processing finalisation work.

## Test plan

- [ ] Run a medium-sized crawl with a sitemap configured and confirm the job ends as `completed` even when manually stopped during the sitemap step
- [ ] Trigger a post-processing-step exception (e.g. transient SQL error in `duplicateAnalysis`) and confirm it no longer flips the crawl to `failed`
- [ ] Confirm `checkStopSignal` still works correctly on the main crawl (where `skip_stop_signal` is unset)