### PR TITLE
docs: marketing-focused README refresh with demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Built by an SEO consultant ([Lokoé](https://lokoe.fr)) for SEO consultants, dev
 | | **Scouter** | Screaming Frog | Sitebulb | LibreCrawl |
 |---|:---:|:---:|:---:|:---:|
 | Open source | ✅ | ❌ | ❌ | ✅ |
-| Free, unlimited URLs | ✅ | ❌ (500 cap) | ❌ | ✅ |
-| Web-based UI | ✅ | ❌ | ❌ | ✅ |
-| Self-hosted | ✅ | Desktop only | Desktop only | ✅ |
-| Multi-user | ✅ | ❌ | ❌ | ⚠️ |
-| JavaScript rendering | ✅ | ✅ | ✅ | ⚠️ |
+| Free, unlimited URLs | ✅ | ❌ | ❌ | ✅ |
+| Web-based UI | ✅ | ❌ | ✅ | ✅ |
+| Self-hosted | ✅ | ❌ | ❌ | ✅ |
+| Multi-user | ✅ | ❌ | ✅ | ✅ |
+| JavaScript rendering | ✅ | ✅ | ✅ | ✅ |
 | Internal PageRank | ✅ | ✅ | ✅ | ❌ |
-| Custom extractors (XPath / Regex) | ✅ | ✅ | ✅ | ⚠️ |
+| Custom extractors (XPath / Regex) | ✅ | ✅ | ✅ | ❌ |
 | SQL queries on crawl data | ✅ | ❌ | ❌ | ❌ |
 | **AI assistant (chat with your crawl)** | ✅ | ❌ | ❌ | ❌ |
 | **AI page categorisation** | ✅ | ❌ | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -1,269 +1,236 @@
-# Scouter
+<div align="center">
+
+# 🛰️ Scouter
+
+### The open-source SEO crawler built for the AI era
+
+**AI-powered. MCP-ready. Self-hosted. Free forever.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)
-![Made with Love](https://img.shields.io/badge/Made%20with-❤️-red)
+[![Version](https://img.shields.io/badge/version-2.0.0-blue)]()
+[![PHP](https://img.shields.io/badge/PHP-8.1+-purple)]()
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-blue)]()
+[![Docker](https://img.shields.io/badge/Docker-required-blue)]()
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](#-contributing)
 
-**Professional SEO Crawler** with web-based analysis interface, built by [Lokoé](https://lokoe.fr).
+[**Quick start**](#-quick-start) · [**Features**](#-key-features) · [**Why Scouter**](#-why-scouter) · [**Docs**](#-documentation)
 
-![Version](https://img.shields.io/badge/version-2.0.0-blue)
-![PHP](https://img.shields.io/badge/PHP-8.1+-purple)
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-blue)
-![Docker](https://img.shields.io/badge/Docker-required-blue)
+</div>
 
 ---
-<img width="1913" height="952" alt="image" src="https://github.com/user-attachments/assets/004ecad5-1479-468e-a34f-c6dc3bbae312" />
 
-## Quick Install
+<div align="center">
+
+<img width="1913" height="952" alt="Scouter Dashboard" src="https://github.com/user-attachments/assets/004ecad5-1479-468e-a34f-c6dc3bbae312" />
+
+### 🎬 Watch the 2-minute demo
+
+[![Watch the Scouter demo](https://img.youtube.com/vi/WjL4pgtBM6w/maxresdefault.jpg)](https://youtu.be/WjL4pgtBM6w)
+
+*Click the thumbnail to see Scouter crawl, analyse and chat with a real site.*
+
+</div>
+
+---
+
+## What is Scouter?
+
+Scouter is a full-featured SEO crawler you run on your own server. Think Screaming Frog — but web-based, multi-user, **free**, fully open source, and now AI-native with a built-in MCP server so your favourite agents can crawl, query, and analyse sites on their own.
+
+Built by an SEO consultant ([Lokoé](https://lokoe.fr)) for SEO consultants, devs, and anyone tired of paying $259/year for a desktop tool that hasn't changed since 2010.
+
+---
+
+## ✨ Why Scouter?
+
+- 🤖 **AI-native** — embedded chatbot (Dr. Brief) that analyses your crawl conversationally. Auto-categorise pages with LLMs. No upsell, no API-key gymnastics.
+- 🔌 **MCP server included** — plug Scouter into Claude, Cursor, or any MCP client and let your agents trigger crawls and query SEO data on their own. **The first open-source SEO crawler with native MCP support.**
+- 🌐 **Modern web UI** — multi-user, multi-project, accessible from anywhere on your network. No clunky desktop app, no file-locking nightmares.
+- 🆓 **Genuinely free** — no URL caps, no feature gates, no "pro tier coming soon".
+- 🐳 **One-command Docker install** — running in under 2 minutes.
+
+---
+
+## 🆚 How Scouter compares
+
+| | **Scouter** | Screaming Frog | Sitebulb | LibreCrawl |
+|---|:---:|:---:|:---:|:---:|
+| Open source | ✅ | ❌ | ❌ | ✅ |
+| Free, unlimited URLs | ✅ | ❌ (500 cap) | ❌ | ✅ |
+| Web-based UI | ✅ | ❌ | ❌ | ✅ |
+| Self-hosted | ✅ | Desktop only | Desktop only | ✅ |
+| Multi-user | ✅ | ❌ | ❌ | ⚠️ |
+| JavaScript rendering | ✅ | ✅ | ✅ | ⚠️ |
+| Internal PageRank | ✅ | ✅ | ✅ | ❌ |
+| Custom extractors (XPath / Regex) | ✅ | ✅ | ✅ | ⚠️ |
+| SQL queries on crawl data | ✅ | ❌ | ❌ | ❌ |
+| **AI assistant (chat with your crawl)** | ✅ | ❌ | ❌ | ❌ |
+| **AI page categorisation** | ✅ | ❌ | ❌ | ❌ |
+| **MCP server** | ✅ | ❌ | ❌ | ❌ |
+| Price | **Free** | $259/yr | from $13.5/mo | Free |
+
+---
+
+## 🔥 Key features
+
+### 🤖 AI-powered
+
+- **Dr. Brief** — embedded AI assistant that answers questions about your crawl in plain English: *"which pages have weak internal linking?"*, *"summarise my duplicate content issues"*, *"flag the URLs missing structured data"*.
+- **AI categorisation** — auto-classify pages by intent, template, or any custom taxonomy.
+- **Bring your own LLM** — works with OpenAI, Anthropic, Gemini, or local stacks (Ollama, vLLM).
+
+### 🔌 MCP server
+
+- Native [Model Context Protocol](https://modelcontextprotocol.io) server.
+- Trigger crawls, query results, and generate reports from Claude, Cursor, or any MCP client.
+- Build real SEO agents that actually have crawl data to work with.
+
+### 🕷️ Crawl engine
+
+- Configurable depth (0 to N), parallelism, and user agent.
+- Respects `robots.txt` (Allow / Disallow).
+- Canonical detection and tracking.
+- **JavaScript rendering** via Go + Chromedp — full SPA support.
+- Distributed async workers (Docker-based).
+- Resume, stop, and restart any crawl.
+
+### 📊 SEO analysis
+
+- On-page: title, H1, meta description, heading structure, word count.
+- Technical: status codes, response times, redirect chains.
+- Duplicate content detection (Simhash).
+- Structured data (JSON-LD) detection.
+- Internal linking analysis with **PageRank computation**.
+- Sitemap analysis: XML parsing, coverage gaps, orphan pages.
+
+### 🎯 Custom extraction
+
+- XPath extractors on any HTML element.
+- Regex extractors on raw source.
+- YAML *or* visual drag-and-drop categorisation rules.
+
+### 🎨 Interface
+
+- Multi-project dashboard with charts and KPIs.
+- Filterable URL explorer (filter by any column, any condition).
+- Built-in **SQL explorer** for custom queries on crawl data.
+- CSV export.
+- Multi-user roles: admin / user / viewer.
+
+---
+
+## 🚀 Quick start
 
 ```bash
-git clone https://github.com/lokoe-mehdi/scouter.git && cd scouter && chmod +x start.sh && ./start.sh
+git clone https://github.com/lokoe-mehdi/scouter.git
+cd scouter
+chmod +x start.sh && ./start.sh
 ```
+
+Then open [http://localhost:8080](http://localhost:8080) and create your admin account.
 
 **Requirements:** Linux or WSL on Windows, with Docker installed.
 
-**Access:** http://localhost:8080
-On first launch, you'll be prompted to create an admin account.
+### Deploy with Coolify
 
-### Deployment
-
-Scouter can also be easily deployed with [Coolify](https://coolify.io/) using the provided `docker-compose.yml`.
+Scouter ships with a production-ready `docker-compose.yml`. One-click deploy on [Coolify](https://coolify.io/) or any Docker host.
 
 ---
 
-## Features
+## 🛠️ Tech stack
 
-### Crawl
-- **Multi-depth**: Configurable crawl depth (0 to N)
-- **Robots.txt**: Respects Allow/Disallow directives
-- **Canonical**: Detection and tracking of canonical tags
-- **JavaScript**: Rendering mode via Puppeteer (SPA support)
-- **Parallelism**: Configurable concurrent requests
-- **Docker Workers**: Distributed architecture with async workers
+| Layer | Tech |
+|---|---|
+| Backend | PHP 8.1+ |
+| Database | PostgreSQL 15+ |
+| JS rendering | Go + Chromedp |
+| Containerisation | Docker + Docker Compose |
+| Frontend | Vanilla HTML / CSS / JS (no build step) |
+| Tests | Pest PHP |
 
-### SEO Analysis
-- **On-page**: Title, H1, meta description, headings
-- **Technical**: HTTP status codes, response times, redirects
-- **Content**: Word count, duplicate detection (Simhash)
-- **Structured Data**: JSON-LD schema detection
-- **Internal Linking**: Inlinks, outlinks, internal PageRank
-
-### Custom Extractors
-- **XPath**: Extract any HTML element
-- **Regex**: Pattern matching on source code
-
-### Categorization
-- **YAML Editor**: Configure categorization rules
-- **Visual Mode**: Drag & drop interface for rules
-- **Test Mode**: Preview before applying
-- **Default Template**: `cat.yml` applied automatically
-
-### Interface
-- **Dashboard**: Overview with charts
-- **Explorer**: Filterable table of all URLs
-- **SQL Explorer**: Custom SQL queries
-- **CSV Export**: Data download
-- **Multi-user Management**: Admin/user/viewer roles
-
----
-
-## Architecture
+<details>
+<summary>📁 Repository layout</summary>
 
 ```
 scouter/
 ├── app/
-│   ├── Analysis/           # SEO analysis
-│   │   ├── PostProcessor.php   # Crawl post-processing
-│   │   ├── RobotsTxt.php       # Robots.txt parser
-│   │   └── Simhash.php         # Duplicate detection
-│   ├── Auth/               # Authentication
-│   │   └── Auth.php            # Session & permission management
-│   ├── Cli/                # CLI tools
-│   │   └── Cmder.php           # Crawl/resume/stop commands
-│   ├── Core/               # Crawler core
-│   │   ├── Crawler.php         # Main orchestrator
-│   │   ├── DepthCrawler.php    # Depth-based crawling
-│   │   ├── Page.php            # Page analysis
-│   │   └── PageCrawler.php     # Single page crawl
-│   ├── Database/           # Data layer (PostgreSQL)
-│   │   ├── PostgresDatabase.php    # Singleton connection
-│   │   ├── CrawlDatabase.php       # Crawl queries
-│   │   ├── CrawlRepository.php     # Crawl CRUD
-│   │   ├── ProjectRepository.php   # Project CRUD
-│   │   ├── UserRepository.php      # User CRUD
-│   │   ├── CategoryRepository.php  # Category CRUD
-│   │   ├── PageRepository.php      # Page CRUD
-│   │   └── LinkRepository.php      # Link CRUD
-│   ├── Http/               # HTTP layer (REST API)
-│   │   ├── Router.php          # REST router
-│   │   ├── Request.php         # HTTP request wrapper
-│   │   ├── Response.php        # JSON responses
-│   │   ├── Controller.php      # Base controller class
-│   │   └── Controllers/        # API controllers
-│   │       ├── ProjectController.php
-│   │       ├── CrawlController.php
-│   │       ├── UserController.php
-│   │       ├── CategoryController.php
-│   │       ├── CategorizationController.php
-│   │       ├── JobController.php
-│   │       ├── QueryController.php
-│   │       ├── ExportController.php
-│   │       └── MonitorController.php
-│   ├── Job/                # Async job management
-│   │   └── JobManager.php      # Queue and job status
-│   ├── Util/               # Utilities
-│   │   ├── HtmlParser.php      # XPath/Regex parsing
-│   │   ├── JsRenderer.php      # JavaScript rendering client
-│   │   └── UrlHelper.php       # URL manipulation
-│   └── bin/                # Executable scripts
-│       └── worker.php          # Docker worker
-├── web/                    # Web interface
-│   ├── api/
-│   │   └── index.php       # Single REST API entry point
-│   ├── pages/              # HTML pages
-│   ├── components/         # Reusable components
-│   └── assets/             # CSS/JS
-├── docker/                 # Docker configuration
-├── migrations/             # PostgreSQL migrations
-├── tests/                  # Tests (Pest)
-│   ├── Unit/               # Unit tests
-│   └── Feature/            # Feature tests
-├── docs/                   # Documentation
-│   ├── phpdoc/             # PHP documentation (Doctum)
-│   ├── ARCHITECTURE.md     # Technical architecture
-│   ├── ROUTER.md           # Router documentation
-│   ├── TESTING.md          # Testing guide
-│   └── ...
-└── cat.yml                 # Default categorization template
+│   ├── Analysis/       # SEO analysis (Simhash, robots.txt, post-processing)
+│   ├── Auth/           # Authentication & permissions
+│   ├── Cli/            # CLI commands (crawl, resume, stop)
+│   ├── Core/           # Crawler core (orchestrator, depth, page)
+│   ├── Database/       # PostgreSQL repositories
+│   ├── Http/           # REST API (router, controllers)
+│   ├── Job/            # Async job manager
+│   └── Util/           # XPath/Regex parser, JS renderer client
+├── renderer/           # Go + Chromedp JS renderer
+├── web/                # Web UI (pages, components, assets, API)
+├── docker/             # Docker configuration
+├── migrations/         # PostgreSQL migrations
+├── tests/              # Pest tests (Unit + Feature)
+├── docs/               # Documentation
+└── cat.yml             # Default categorisation template
 ```
 
-### Tech Stack
-
-| Component | Technology |
-|-----------|------------|
-| Backend | PHP 8.1+ |
-| Database | PostgreSQL 15+ |
-| Frontend | HTML/CSS/JS vanilla |
-| Containerization | Docker + Docker Compose |
-| Tests | Pest PHP |
-| Documentation | Doctum |
-| JS Rendering | Go + Chromedp |
+</details>
 
 ---
 
-## Documentation
+## 📚 Documentation
 
-### User Guides
-- [Installation](docs/INSTALLATION.md) - Docker, configuration, first launch
-- [Usage](docs/UTILISATION.md) - User interface guide
-- [Architecture](docs/ARCHITECTURE.md) - Database, API, migrations
+- [Installation](docs/INSTALLATION.md) — Docker, configuration, first launch
+- [Usage guide](docs/UTILISATION.md) — the UI, step by step
+- [Architecture](docs/ARCHITECTURE.md) — database, API, migrations
+- [REST API reference](docs/ROUTER.md)
+- [Worker architecture](docs/WORKER_ARCHITECTURE_PLAN.md)
+- [Testing guide](docs/TESTING.md)
+- [PHP class reference](docs/phpdoc/index.html) — generated with Doctum
 
-### Technical Documentation
-- [PHP Documentation](docs/phpdoc/index.html) - Class documentation (Doctum)
-- [REST Router](docs/ROUTER.md) - Architecture and API endpoints
-- [Tests](docs/TESTING.md) - Unit testing guide with Pest
-- [Workers](docs/WORKER_ARCHITECTURE_PLAN.md) - Docker worker architecture
-
-### Generate PHP Documentation
+### Useful commands
 
 ```bash
-./generate-docs.sh
-# Output in docs/phpdoc/
+./start.sh                                          # Start (rebuild + up)
+docker-compose down                                 # Stop
+docker-compose logs -f app                          # Application logs
+docker-compose logs -f worker                       # Worker logs
+docker exec -it scouter bash                        # Container shell
+docker exec scouter php /app/migrations/migrate.php # Run migrations
+docker exec scouter ./vendor/bin/pest               # Run tests
+./generate-docs.sh                                  # Regenerate PHP docs
 ```
 
 ---
 
-## Useful Commands
+## 🗺️ Roadmap
 
-### Docker
-```bash
-./start.sh                              # Start (rebuild + up)
-docker-compose down                     # Stop
-docker-compose logs -f app              # Application logs
-docker-compose logs -f worker           # Worker logs
-docker exec -it scouter bash            # Container shell
-```
+- [ ] Public hosted demo
+- [ ] First-class local-LLM support (Ollama, vLLM, ZML)
+- [ ] Scheduled recurring crawls
+- [ ] Slack / Discord webhooks on crawl issues
+- [ ] More MCP tools: natural-language SQL, automated categorisation flows
+- [ ] Plugin system for custom analysers
 
-### Database
-```bash
-docker exec scouter php /app/migrations/migrate.php  # Run migrations
-```
-
-### Tests
-```bash
-./vendor/bin/pest                       # Run tests (local)
-docker exec scouter ./vendor/bin/pest   # Run tests (Docker)
-```
-
-### Documentation
-```bash
-./generate-docs.sh                      # Generate API docs
-```
+See [open issues](https://github.com/lokoe-mehdi/scouter/issues) for the full list.
 
 ---
 
-## REST API
+## 🤝 Contributing
 
-The API uses a centralized router (`web/api/index.php`) with the following endpoints:
+PRs welcome — open an issue first if you're planning a large change so we can align.
 
-### Projects
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/projects` | List projects |
-| POST | `/api/projects` | Create a project/crawl |
-| DELETE | `/api/projects/{id}` | Delete a project |
-| POST | `/api/projects/duplicate` | Duplicate a crawl |
-
-### Crawls
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/crawls/info` | Crawl info |
-| GET | `/api/crawls/running` | Running crawls |
-| POST | `/api/crawls/start` | Start a crawl |
-| POST | `/api/crawls/stop` | Stop a crawl |
-| POST | `/api/crawls/resume` | Resume a crawl |
-
-### Categorization
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/categorization/save` | Save and apply |
-| POST | `/api/categorization/test` | Test without applying |
-| GET | `/api/categorization/stats` | Statistics |
-
-### Users (admin)
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/users` | List users |
-| POST | `/api/users` | Create a user |
-| PUT | `/api/users/{id}` | Update a user |
-| DELETE | `/api/users/{id}` | Delete a user |
+If you build something cool on top of Scouter (an integration, a custom analyser, an agent), please share it. The point of going open source is to compound on what each of us builds.
 
 ---
 
-## Main Classes
+## 📄 License
 
-| Namespace | Class | Description |
-|-----------|-------|-------------|
-| `App\Core` | `Crawler` | Main crawl orchestrator |
-| `App\Core` | `DepthCrawler` | Depth-based crawling with parallel requests |
-| `App\Core` | `Page` | Page data analysis and extraction |
-| `App\Database` | `PostgresDatabase` | PostgreSQL singleton connection |
-| `App\Database` | `CrawlRepository` | Crawl CRUD operations |
-| `App\Database` | `ProjectRepository` | Project CRUD operations |
-| `App\Auth` | `Auth` | Authentication and access control |
-| `App\Analysis` | `RobotsTxt` | Robots.txt parsing and interpretation |
-| `App\Analysis` | `Simhash` | Duplicate content detection |
-| `App\Util` | `JsRenderer` | JavaScript rendering client |
-| `App\Http` | `Router` | REST API router |
-| `App\Job` | `JobManager` | Async job management |
+MIT — see [LICENSE](LICENSE). Copyright © 2026 **Lokoé SASU**.
 
 ---
 
-## License
+<div align="center">
 
-This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
+**Built with ❤️ by [Lokoé](https://lokoe.fr) — an indie SEO consultant.**
 
-Copyright (c) 2026 **Lokoé SASU**
+⭐ Star the repo if Scouter saves you a Screaming Frog licence. It really helps.
 
-
-**Scouter** - Professional SEO Crawler by [Lokoé](https://lokoe.fr)
+</div>


### PR DESCRIPTION
## Summary

Marketing-focused rewrite of the README, built around the AI-native / MCP positioning.

- New centered header (the opening `<div align="center">` was missing in the draft — fixed), a clear value proposition, and a comparison table vs Screaming Frog / Sitebulb / LibreCrawl.
- Reorganised feature sections (AI, MCP, crawl engine, SEO analysis, extraction, interface), quick start, collapsible tech stack, roadmap and contributing.
- Keeps the existing dashboard screenshot (GitHub attachment) **and** adds a YouTube demo video as a clickable thumbnail — GitHub does not allow `iframe` embeds in a README, so a thumbnail linking to https://youtu.be/WjL4pgtBM6w is the standard approach.
- Cleaned up formatting (anchor links, tables, code blocks).

## Fact-checked comparison table

Every cell is now strictly binary (✅ / ❌, no partial markers), verified against each competitor's docs:
- **Sitebulb** — web-based UI (Sitebulb Cloud) ✅, multi-user (teams) ✅, custom extraction (XPath/CSS/Regex) ✅, link-equity/PageRank distribution ✅; not self-hosted ❌.
- **LibreCrawl** — multi-tenant (multi-user) ✅, JavaScript rendering ✅; no built-in custom extractors and no internal PageRank ❌.
- **Screaming Frog** — Link Score = internal PageRank ✅, custom extraction ✅; official price ~£199/yr (≈ $259).

## Notes

- The demo video points to `WjL4pgtBM6w` (ID extracted from the URL provided). Please confirm it is the intended demo video.
- Branch is based on `develop`; the PR targets `develop`.

https://claude.ai/code/session_013TyG5pRJLFAy3EQGgfgJUs