### PR TITLE
fix/ux: crawler scalability at multi-million URLs + faster home/project pages

### DIFF
--- a/app/Analysis/CrawlStats.php
+++ b/app/Analysis/CrawlStats.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Analysis;
+
+use App\Database\ClickHouseDatabase;
+use App\Database\PostgresDatabase;
+
+/**
+ * Stats de crawl dérivées de ClickHouse, calculées UNE fois et persistées dans
+ * la ligne `crawls` (write-through). Une seule requête CH batchée produit :
+ *   - compliant        (pages indexables)
+ *   - critical_errors  (4xx/5xx sur pages crawlées)
+ *   - health_score     (score santé SEO 5 piliers : indexabilité, on-page title+h1
+ *                       uniques, contenu non-thin, distribution PageRank, profondeur)
+ *
+ * Sentinelle : `crawls.health_score IS NULL` = pas encore calculé. Une fois posé
+ * (non-NULL), la home et la page projet lisent simplement la ligne `crawls` →
+ * ZÉRO requête ClickHouse au rendu.
+ *
+ * Déclenché :
+ *   (1) au post-crawl, via le job `precompute-reports:<id>` (scouter.php) → tout
+ *       nouveau crawl a ses 3 stats stockées d'office ;
+ *   (2) paresseusement, à la 1re consultation d'un ancien crawl (index.php /
+ *       project.php) → calcul live une seule fois + write-through, puis instantané.
+ *
+ * Le score est IMMUABLE post-crawl (indexabilité / on-page / contenu / pagerank /
+ * profondeur — indépendant des catégories) → stockage permanent sûr, jamais
+ * invalidé à l'édition des catégories.
+ */
+class CrawlStats
+{
+    /**
+     * Calcule compliant + critical_errors + health_score en ClickHouse pour les
+     * crawls donnés, persiste dans `crawls`, et retourne
+     * [crawl_id => ['compliant'=>int, 'critical_errors'=>int, 'health_score'=>int]].
+     * Seuls les crawls réellement présents dans ClickHouse sont renvoyés/persistés
+     * (les autres → absents : l'appelant retombe sur pcHealthScore). Retourne []
+     * si ClickHouse est désactivé.
+     */
+    public static function ensureFromClickHouse(array $crawlIds): array
+    {
+        $crawlIds = array_values(array_unique(array_filter(array_map('intval', $crawlIds))));
+        if (empty($crawlIds) || !ClickHouseDatabase::enabled()) {
+            return [];
+        }
+        $idList = implode(',', $crawlIds);
+
+        // pages est un ReplacingMergeTree → on déduplique (LIMIT 1 BY crawl_id,id)
+        // AVANT d'agréger. title_status/h1_status/pri vivent dans page_metrics.
+        // Score 5 piliers + compliant (indexables) + critical_errors dans la même
+        // passe. Repli pur-PHP (sans CH) : pcHealthScore() dans project-metrics.php.
+        $sql = "
+WITH per AS (
+  SELECT crawl_id, countIf(compliant=1 AND is_html=1) AS idx
+  FROM (SELECT crawl_id, id, compliant, is_html FROM pages WHERE crawl_id IN ($idList)
+        ORDER BY date DESC LIMIT 1 BY crawl_id, id)
+  GROUP BY crawl_id
+),
+thr AS (SELECT crawl_id, greatest(ceil(log((idx + 24) / 25.0) / log(5.0)), 1) AS max_depth FROM per)
+SELECT p.crawl_id AS crawl_id,
+  countIf(p.compliant=1) AS compliant,
+  countIf(p.code >= 400 AND p.crawled=1) AS critical_errors,
+  round((
+      countIf(p.compliant=1 AND p.is_html=1)*100.0 / nullIf(countIf(p.crawled=1 AND p.is_html=1),0)
+    + countIf(m.title_status='unique' AND m.h1_status='unique' AND p.compliant=1 AND p.is_html=1)*100.0 / nullIf(countIf(p.crawled=1 AND p.is_html=1),0)
+    + countIf(p.compliant=1 AND p.is_html=1 AND p.word_count>500)*100.0 / nullIf(countIf(p.compliant=1 AND p.is_html=1),0)
+    + sumIf(m.pri, p.compliant=1 AND p.is_html=1)*100.0 / nullIf(sum(m.pri),0)
+    + countIf(p.compliant=1 AND p.is_html=1 AND p.depth <= t.max_depth)*100.0 / nullIf(countIf(p.compliant=1 AND p.is_html=1),0)
+  ) / 5) AS score
+FROM (SELECT crawl_id, id, compliant, is_html, crawled, word_count, depth, code FROM pages WHERE crawl_id IN ($idList)
+      ORDER BY date DESC LIMIT 1 BY crawl_id, id) p
+LEFT JOIN page_metrics m ON m.crawl_id = p.crawl_id AND m.id = p.id
+JOIN thr t ON t.crawl_id = p.crawl_id
+GROUP BY p.crawl_id, t.max_depth";
+
+        try {
+            $rows = ClickHouseDatabase::getInstance()->select($sql);
+        } catch (\Throwable $e) {
+            error_log('[CrawlStats] CH query failed: ' . $e->getMessage());
+            return [];
+        }
+        if (empty($rows)) {
+            return [];
+        }
+
+        $out = [];
+        try {
+            $pdo = PostgresDatabase::getInstance()->getConnection();
+            $upd = $pdo->prepare(
+                "UPDATE crawls SET compliant = :compliant, critical_errors = :crit, health_score = :hs WHERE id = :id"
+            );
+            foreach ($rows as $r) {
+                $id = (int) ($r['crawl_id'] ?? 0);
+                if ($id <= 0) {
+                    continue;
+                }
+                $score = (($r['score'] ?? null) !== null && $r['score'] !== '')
+                    ? (int) round(max(0, min(100, (float) $r['score'])))
+                    : 0;
+                $compliant = (int) ($r['compliant'] ?? 0);
+                $crit = (int) ($r['critical_errors'] ?? 0);
+                $upd->execute([':compliant' => $compliant, ':crit' => $crit, ':hs' => $score, ':id' => $id]);
+                $out[$id] = ['compliant' => $compliant, 'critical_errors' => $crit, 'health_score' => $score];
+            }
+        } catch (\Throwable $e) {
+            error_log('[CrawlStats] persist failed: ' . $e->getMessage());
+        }
+        return $out;
+    }
+
+    /**
+     * Fige un health_score déjà calculé (ex. repli pcHealthScore pour un crawl
+     * ABSENT de ClickHouse) afin de poser la sentinelle → plus de recalcul à
+     * chaque consultation. N'écrase pas une valeur déjà posée.
+     */
+    public static function persistHealthScore(int $crawlId, int $score): void
+    {
+        if ($crawlId <= 0) {
+            return;
+        }
+        try {
+            $pdo = PostgresDatabase::getInstance()->getConnection();
+            $stmt = $pdo->prepare("UPDATE crawls SET health_score = :hs WHERE id = :id AND health_score IS NULL");
+            $stmt->execute([':hs' => (int) max(0, min(100, $score)), ':id' => $crawlId]);
+        } catch (\Throwable $e) {
+            error_log('[CrawlStats] persistHealthScore failed: ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Database/CrawlDatabase.php
+++ b/app/Database/CrawlDatabase.php
@@ -507,14 +507,18 @@ class CrawlDatabase
      */
     public function getCurrentDepth(): int
     {
+        // Resume from the LOWEST unfinished depth so the walk stays breadth-first;
+        // without ORDER BY, PG returns an arbitrary uncrawled row and a resume could
+        // jump to a deeper level while a shallower one still had pending URLs.
         $stmt = $this->db->prepare("
             SELECT depth FROM pages
             WHERE crawl_id = :crawl_id AND crawled = false AND external = false AND blocked = false AND in_crawl = TRUE
+            ORDER BY depth ASC
             LIMIT 1
         ");
         $stmt->execute([':crawl_id' => $this->crawlId]);
         $result = $stmt->fetch(PDO::FETCH_OBJ);
-        
+
         return $result ? (int)$result->depth : 0;
     }
 

--- a/crawler-go/go.mod
+++ b/crawler-go/go.mod
@@ -3,6 +3,7 @@ module scouter-crawler
 go 1.25.0
 
 require (
+	github.com/andybalholm/brotli v1.2.0
 	github.com/antchfx/htmlquery v1.3.3
 	github.com/antchfx/xpath v1.3.2
 	github.com/go-shiori/go-readability v0.0.0-20241012063810-92284fa8a71f
@@ -13,7 +14,6 @@ require (
 )
 
 require (
-	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect

--- a/crawler-go/internal/crawl/ch_store.go
+++ b/crawler-go/internal/crawl/ch_store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"io"
 	"sync"
+	"time"
 
 	"scouter-crawler/internal/db"
 )
@@ -21,8 +22,14 @@ const chBatch = 1000
 // (CLICKHOUSE_URL set). Append-only — never updates. Thread-safe: storePage runs
 // from many fetch goroutines at once.
 //
-// A CH failure never aborts the crawl: errors are logged and the buffer dropped,
-// because PostgreSQL remains the source of truth during the transition.
+// Durability: under slim-PG (CLICKHOUSE_DROP_PG, the default) ClickHouse is the
+// ONLY store for links/html/page_schemas — PG keeps just the frontier — so a
+// dropped CH insert is permanent data loss (missing edges ⇒ wrong inlinks /
+// PageRank / orphan reports). Therefore a failed flush is NOT discarded: it is
+// retried with backoff (which also back-pressures the calling fetch goroutine),
+// and if it still fails the batch is put back in the buffer for the next flush /
+// the final Flush to retry. Transient server-memory rejections — the actual
+// failure mode here — heal within seconds once merges free memory.
 type CHStore struct {
 	ch      *db.CH
 	crawlID int
@@ -213,15 +220,72 @@ func (s *CHStore) AddHTMLZipped(id, domZip string) {
 	}
 }
 
-// Flush drains all buffers. Called at crawl/sitemap-pass end before post-processing.
+// Flush drains all buffers, retrying until empty or the context is done. Called
+// at crawl/sitemap-pass end before post-processing — the last chance to land
+// rows that earlier flushes re-buffered after a transient CH rejection.
 func (s *CHStore) Flush(ctx context.Context) {
 	if s == nil {
 		return
 	}
-	s.flushPages(ctx)
-	s.flushLinks(ctx)
-	s.flushSchemas(ctx)
-	s.flushHTML(ctx)
+	for attempt := 0; attempt < 10; attempt++ {
+		s.flushPages(ctx)
+		s.flushLinks(ctx)
+		s.flushSchemas(ctx)
+		s.flushHTML(ctx)
+		s.mu.Lock()
+		remaining := len(s.pages) + len(s.links) + len(s.schemas) + len(s.htmls)
+		s.mu.Unlock()
+		if remaining == 0 {
+			return
+		}
+		// A flush re-buffered its batch (CH still under pressure). Pause and retry
+		// the whole drain rather than leave rows unwritten.
+		select {
+		case <-ctx.Done():
+			s.logf("clickhouse flush aborted with %d rows still buffered: %v", remaining, ctx.Err())
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+	s.mu.Lock()
+	remaining := len(s.pages) + len(s.links) + len(s.schemas) + len(s.htmls)
+	s.mu.Unlock()
+	if remaining > 0 {
+		s.logf("clickhouse flush gave up with %d rows still buffered after retries", remaining)
+	}
+}
+
+// insertWithRetry inserts a batch, retrying with exponential backoff. It returns
+// false only after exhausting its attempts — the caller then re-buffers the batch
+// rather than dropping it. The retry loop blocks the calling fetch goroutine,
+// which is the back-pressure: under CH memory pressure the crawl slows instead of
+// losing rows. The actual failure (server-wide memory limit) is transient and
+// clears within a few seconds as background merges free memory.
+func (s *CHStore) insertWithRetry(ctx context.Context, table, label string, batch []any) bool {
+	const maxAttempts = 6
+	backoff := 250 * time.Millisecond
+	for attempt := 1; ; attempt++ {
+		if err := s.ch.InsertJSONEachRow(ctx, table, batch); err == nil {
+			if attempt > 1 {
+				s.logf("clickhouse %s insert recovered after %d attempts (%d rows)", label, attempt, len(batch))
+			}
+			return true
+		} else if attempt >= maxAttempts {
+			s.logf("clickhouse %s insert failed after %d attempts (%d rows), re-buffering for next flush: %v", label, attempt, len(batch), err)
+			return false
+		} else {
+			s.logf("clickhouse %s insert attempt %d/%d failed (%d rows), retrying in %s: %v", label, attempt, maxAttempts, len(batch), backoff, err)
+		}
+		select {
+		case <-ctx.Done():
+			s.logf("clickhouse %s insert aborted (%d rows) by context: %v", label, len(batch), ctx.Err())
+			return false
+		case <-time.After(backoff):
+		}
+		if backoff < 8*time.Second {
+			backoff *= 2
+		}
+	}
 }
 
 func (s *CHStore) flushPages(ctx context.Context) {
@@ -232,8 +296,10 @@ func (s *CHStore) flushPages(ctx context.Context) {
 	if len(batch) == 0 {
 		return
 	}
-	if err := s.ch.InsertJSONEachRow(ctx, s.ch.DB()+".pages", batch); err != nil {
-		s.logf("clickhouse pages insert failed (%d rows): %v", len(batch), err)
+	if !s.insertWithRetry(ctx, s.ch.DB()+".pages", "pages", batch) {
+		s.mu.Lock()
+		s.pages = append(batch, s.pages...)
+		s.mu.Unlock()
 	}
 }
 
@@ -245,8 +311,10 @@ func (s *CHStore) flushLinks(ctx context.Context) {
 	if len(batch) == 0 {
 		return
 	}
-	if err := s.ch.InsertJSONEachRow(ctx, s.ch.DB()+".links", batch); err != nil {
-		s.logf("clickhouse links insert failed (%d rows): %v", len(batch), err)
+	if !s.insertWithRetry(ctx, s.ch.DB()+".links", "links", batch) {
+		s.mu.Lock()
+		s.links = append(batch, s.links...)
+		s.mu.Unlock()
 	}
 }
 
@@ -258,8 +326,10 @@ func (s *CHStore) flushSchemas(ctx context.Context) {
 	if len(batch) == 0 {
 		return
 	}
-	if err := s.ch.InsertJSONEachRow(ctx, s.ch.DB()+".page_schemas", batch); err != nil {
-		s.logf("clickhouse page_schemas insert failed (%d rows): %v", len(batch), err)
+	if !s.insertWithRetry(ctx, s.ch.DB()+".page_schemas", "page_schemas", batch) {
+		s.mu.Lock()
+		s.schemas = append(batch, s.schemas...)
+		s.mu.Unlock()
 	}
 }
 
@@ -271,8 +341,10 @@ func (s *CHStore) flushHTML(ctx context.Context) {
 	if len(batch) == 0 {
 		return
 	}
-	if err := s.ch.InsertJSONEachRow(ctx, s.ch.DB()+".html", batch); err != nil {
-		s.logf("clickhouse html insert failed (%d rows): %v", len(batch), err)
+	if !s.insertWithRetry(ctx, s.ch.DB()+".html", "html", batch) {
+		s.mu.Lock()
+		s.htmls = append(batch, s.htmls...)
+		s.mu.Unlock()
 	}
 }
 

--- a/crawler-go/internal/crawl/engine.go
+++ b/crawler-go/internal/crawl/engine.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/andybalholm/brotli"
@@ -66,27 +67,95 @@ type Engine struct {
 	retryPauseMu sync.Mutex
 	retryPause   time.Duration
 
-	// throttle for UpdateCrawlStats (each call scans the whole partition; on a
-	// million-page crawl, calling it per 5000-batch would mean thousands of full
-	// scans). Updated at most every statsInterval.
-	statsMu   sync.Mutex
-	lastStats time.Time
+	// stopFlag is set by the background stop-poller so the hot path can test for a
+	// user/worker stop without a per-URL DB round-trip.
+	stopFlag atomic.Bool
+
+	// live stats counters: incremented as pages are stored and written to crawls.*
+	// by the background stats-writer with a cheap UPDATE — no full-partition scans.
+	// Seeded from the authoritative crawls row at start and after each depth-end
+	// recompute, so they stay absolute and self-heal any drift.
+	liveCrawled   atomic.Int64
+	liveCompliant atomic.Int64
+	liveCritical  atomic.Int64
+	liveDepthMax  atomic.Int64
 }
 
 const statsInterval = 10 * time.Second
 
-// maybeUpdateStats refreshes crawls.* stats at most once per statsInterval, to
-// keep the UI progress live without hammering PG with full-partition COUNTs on
-// huge crawls.
-func (e *Engine) maybeUpdateStats(ctx context.Context) {
-	e.statsMu.Lock()
-	if time.Since(e.lastStats) < statsInterval {
-		e.statsMu.Unlock()
+// stopped reports a user/worker stop without touching the DB: the background
+// poller refreshes stopFlag every couple of seconds. Also true once ctx is done.
+func (e *Engine) stopped(ctx context.Context) bool {
+	return e.stopFlag.Load() || ctx.Err() != nil
+}
+
+// seedLiveStats loads the persisted counters into the in-memory tallies so the
+// engine continues from the authoritative values (resume / post-recompute).
+func (e *Engine) seedLiveStats(ctx context.Context) {
+	crawled, compliant, critical, depthMax, err := e.cdb.GetStatsSnapshot(ctx)
+	if err != nil {
 		return
 	}
-	e.lastStats = time.Now()
-	e.statsMu.Unlock()
-	_ = e.cdb.UpdateCrawlStats(ctx)
+	e.liveCrawled.Store(crawled)
+	e.liveCompliant.Store(compliant)
+	e.liveCritical.Store(critical)
+	e.liveDepthMax.Store(depthMax)
+}
+
+// recordStored bumps the live counters for one freshly-crawled page.
+func (e *Engine) recordStored(depth, code int, compliant bool) {
+	e.liveCrawled.Add(1)
+	if compliant {
+		e.liveCompliant.Add(1)
+	}
+	if code >= 400 {
+		e.liveCritical.Add(1)
+	}
+	for {
+		cur := e.liveDepthMax.Load()
+		if int64(depth) <= cur || e.liveDepthMax.CompareAndSwap(cur, int64(depth)) {
+			break
+		}
+	}
+}
+
+// writeLiveStats persists the current counters with one cheap UPDATE.
+func (e *Engine) writeLiveStats(ctx context.Context) {
+	_ = e.cdb.WriteLiveStats(ctx, e.liveCrawled.Load(), e.liveCompliant.Load(),
+		e.liveCritical.Load(), e.liveDepthMax.Load())
+}
+
+// runStopPoller refreshes stopFlag off the hot path: one status query every 2s
+// instead of one per URL. Exits as soon as a stop is observed (flag stays set).
+func (e *Engine) runStopPoller(ctx context.Context) {
+	t := time.NewTicker(2 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if e.stopCheck(ctx) {
+				e.stopFlag.Store(true)
+				return
+			}
+		}
+	}
+}
+
+// runStatsWriter persists the live counters every statsInterval, off the crawl
+// driver goroutine so a slow stats write never stalls fetch dispatch.
+func (e *Engine) runStatsWriter(ctx context.Context) {
+	t := time.NewTicker(statsInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			e.writeLiveStats(ctx)
+		}
+	}
 }
 
 // RetryPause returns the cumulative time spent sleeping in retry backoff, so the

--- a/crawler-go/internal/crawl/orchestrator.go
+++ b/crawler-go/internal/crawl/orchestrator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"scouter-crawler/internal/analysis"
 	"scouter-crawler/internal/db"
@@ -20,8 +22,31 @@ func (e *Engine) Crawl(ctx context.Context, newCrawl bool) error {
 		if err := e.insertStart(ctx); err != nil {
 			return err
 		}
+	} else {
+		// Resume: a fresh worker must be able to re-lease URLs the previous process
+		// claimed but never crawled, without waiting out the 10-minute lease.
+		_ = e.cdb.ResetClaims(ctx)
 	}
-	return e.depthStarter(ctx, newCrawl)
+
+	// Seed the live counters from the authoritative crawls row, then run the
+	// stop-poller and stats-writer alongside the walk so neither a status check nor
+	// a stats write ever sits on the fetch-dispatch path (the cause of the freeze on
+	// huge crawls). They're bound to bgCtx, cancelled the moment the walk returns.
+	e.seedLiveStats(ctx)
+	bgCtx, cancelBg := context.WithCancel(ctx)
+	var bg sync.WaitGroup
+	bg.Add(2)
+	go func() { defer bg.Done(); e.runStopPoller(bgCtx) }()
+	go func() { defer bg.Done(); e.runStatsWriter(bgCtx) }()
+
+	err := e.depthStarter(ctx, newCrawl)
+
+	cancelBg()
+	bg.Wait()
+	// Final flush of the live counters (best-effort) so the last batch's count is
+	// persisted even before the worker's finish-time UpdateCrawlStats.
+	e.writeLiveStats(context.Background())
+	return err
 }
 
 // FetchURLs fetches a flat list of URLs at depth=-1 (sitemap-only pass). Used by
@@ -73,12 +98,19 @@ func (e *Engine) insertURLList(ctx context.Context) error {
 	return e.cdb.InsertPages(ctx, pages)
 }
 
+// frontierOpTimeout caps a single frontier claim/count so a pathological scan is
+// cancelled by the DB instead of wedging the driver goroutine forever (the
+// idx_pages_frontier partial index keeps these in the millisecond range, so this
+// only ever trips on genuine DB trouble).
+const frontierOpTimeout = 60 * time.Second
+
 // depthStarter ports Crawler::depthStarter: iterate depths 0..depthMax, draining
-// each via batches of frontierBatch, with a safety cap on redirect-cycle passes.
+// each by leasing batches of frontierBatch from the frontier queue until none
+// remain.
 func (e *Engine) depthStarter(ctx context.Context, newCrawl bool) error {
 	respectRobots := e.cfg.RespectRobots
 	for i := 0; i <= e.cfg.DepthMax; i++ {
-		if e.stopCheck(ctx) {
+		if e.stopped(ctx) {
 			return errStopped
 		}
 		if !newCrawl {
@@ -86,12 +118,12 @@ func (e *Engine) depthStarter(ctx context.Context, newCrawl bool) error {
 				i = dr
 			}
 		}
-		total, err := e.cdb.CountUrlsToCrawl(ctx, respectRobots, i)
+		total, err := e.countToCrawl(ctx, respectRobots, i)
 		if err != nil {
 			return err
 		}
 		if total == 0 {
-			any, err := e.cdb.CountUrlsToCrawl(ctx, respectRobots, -1)
+			any, err := e.countToCrawl(ctx, respectRobots, -1)
 			if err != nil {
 				return err
 			}
@@ -103,41 +135,46 @@ func (e *Engine) depthStarter(ctx context.Context, newCrawl bool) error {
 
 		e.startDepthProgress(i, total)
 
-		// Drain the whole depth: keep pulling batches until none remain. No fixed
-		// pass cap — the old 50-pass cap silently truncated large depths at
-		// 50*frontierBatch (=250k) URLs. Termination is guaranteed: every fetched
-		// page is marked crawled=true and ON CONFLICT dedups already-seen URLs, so
-		// the depth-i frontier strictly shrinks. Guard against a pathological page
-		// that never gets marked (e.g. a persistent store error): if the head of
-		// the queue doesn't advance across several passes, bail out of this depth.
-		prevHead := ""
-		stuck := 0
+		// Drain the whole depth: keep leasing batches until none remain. Termination
+		// is guaranteed — every leased URL is either marked crawled=true or keeps its
+		// claim stamp, so ClaimUrlsToCrawl never hands the same row back within the
+		// depth (no stuck-head guard needed: the claim is the guard).
 		for {
-			if e.stopCheck(ctx) {
+			if e.stopped(ctx) {
 				return errStopped
 			}
-			urls, err := e.cdb.GetUrlsToCrawl(ctx, respectRobots, frontierBatch, i)
+			urls, err := e.claimToCrawl(ctx, respectRobots, frontierBatch, i)
 			if err != nil {
 				return err
 			}
 			if len(urls) == 0 {
 				break
 			}
-			if urls[0] == prevHead {
-				if stuck++; stuck >= 3 {
-					e.logf("depth %d: queue head not advancing (%s) — leaving this depth to avoid a loop", i, urls[0])
-					break
-				}
-			} else {
-				stuck = 0
-				prevHead = urls[0]
-			}
 			e.processURLs(ctx, urls, i)
-			e.maybeUpdateStats(ctx) // throttled: avoids a full-partition scan per batch
 		}
-		_ = e.cdb.UpdateCrawlStats(ctx) // accurate count at the end of each depth
+		// Authoritative recompute at the end of each depth (urls/duplicates/
+		// in_progress/response_time the live writer doesn't track), then reseed the
+		// live counters from it so they stay exact.
+		if err := e.cdb.UpdateCrawlStats(ctx); err != nil {
+			e.logf("depth %d: stats refresh failed: %v", i, err)
+		}
+		e.seedLiveStats(ctx)
 	}
 	return nil
+}
+
+// claimToCrawl leases one frontier batch under a timeout (see frontierOpTimeout).
+func (e *Engine) claimToCrawl(ctx context.Context, respectRobots bool, limit, depth int) ([]string, error) {
+	cctx, cancel := context.WithTimeout(ctx, frontierOpTimeout)
+	defer cancel()
+	return e.cdb.ClaimUrlsToCrawl(cctx, respectRobots, limit, depth)
+}
+
+// countToCrawl counts the remaining frontier at a depth under a timeout.
+func (e *Engine) countToCrawl(ctx context.Context, respectRobots bool, depth int) (int, error) {
+	cctx, cancel := context.WithTimeout(ctx, frontierOpTimeout)
+	defer cancel()
+	return e.cdb.CountUrlsToCrawl(cctx, respectRobots, depth)
 }
 
 // errStopped signals a user/worker stop during the walk.

--- a/crawler-go/internal/crawl/process.go
+++ b/crawler-go/internal/crawl/process.go
@@ -42,7 +42,7 @@ func (e *Engine) processClassic(ctx context.Context, urls []string, depth int) [
 	}
 
 	for _, u := range urls {
-		if e.stopCheck(ctx) || ctx.Err() != nil {
+		if e.stopped(ctx) {
 			break
 		}
 		if tick != nil {
@@ -81,7 +81,7 @@ func (e *Engine) processClassic(ctx context.Context, urls []string, depth int) [
 // (2/4/8/16s ±20% jitter), storing on success or on the final attempt.
 func (e *Engine) retryFailed(ctx context.Context, failed []string, depth int) {
 	for attempt := 1; attempt <= maxRetries && len(failed) > 0; attempt++ {
-		if e.stopCheck(ctx) || ctx.Err() != nil {
+		if e.stopped(ctx) {
 			return
 		}
 		delay := time.Duration(int64(baseDelay) << uint(attempt-1)) // 2,4,8,16s

--- a/crawler-go/internal/crawl/renderer.go
+++ b/crawler-go/internal/crawl/renderer.go
@@ -71,11 +71,10 @@ func (e *Engine) processJavascript(ctx context.Context, urls []string, depth int
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var failed []string
-	var rr uint64      // round-robin renderer selector
-	var batchSeq int64 // completed batches (for periodic stats refresh)
+	var rr uint64 // round-robin renderer selector
 
 	for b := 0; b < len(urls); b += batchPerRenderer {
-		if e.stopCheck(ctx) || ctx.Err() != nil {
+		if e.stopped(ctx) {
 			break
 		}
 		be := b + batchPerRenderer
@@ -124,17 +123,13 @@ func (e *Engine) processJavascript(ctx context.Context, urls []string, depth int
 					e.tickProgress(depth)
 				}
 			}
-			// Live feedback: progress line is throttled internally (250ms); refresh
-			// the crawls.crawled stat every few batches so the UI count climbs.
+			// Live feedback: progress line is throttled internally (250ms). The crawls.*
+			// counters are persisted off this path by the background stats-writer.
 			e.emitProgress(depth, false)
-			if atomic.AddInt64(&batchSeq, 1)%int64(maxConcurrent) == 0 {
-				_ = e.cdb.UpdateCrawlStats(ctx)
-			}
 		}(batch)
 	}
 	wg.Wait()
 	e.emitProgress(depth, true)
-	_ = e.cdb.UpdateCrawlStats(ctx)
 	return failed
 }
 

--- a/crawler-go/internal/crawl/store.go
+++ b/crawler-go/internal/crawl/store.go
@@ -81,6 +81,8 @@ func (e *Engine) storePage(ctx context.Context, p model.Page, depth int) error {
 	if err := e.cdb.UpdatePage(ctx, p.ID, sets); err != nil {
 		return err
 	}
+	// Page is now crawled=true: bump the live counters the background writer persists.
+	e.recordStored(depth, p.HTTPCode, compliant)
 	// Dual-write the crawled page to ClickHouse (append-only; observed signals only).
 	e.chStore.AddPage(chPageRow{
 		CrawlID: e.cdb.CrawlID, ID: p.ID, Domain: p.Domain, URL: p.URL, Depth: depth,

--- a/crawler-go/internal/db/clickhouse.go
+++ b/crawler-go/internal/db/clickhouse.go
@@ -44,6 +44,14 @@ type CH struct {
 	// report queries and the rest of the host, without ever capping cores (stays
 	// adaptive: no machine-specific core count). See buildCHSettings.
 	settings url.Values
+	// insertSettings is a `SETTINGS …` clause appended to every INSERT (only —
+	// not to SELECTs/DDL). It enables server-side async inserts so the crawler's
+	// many small concurrent batches (1000 rows from N fetch goroutines) are
+	// coalesced by ClickHouse into few large parts instead of one part per batch.
+	// Fewer parts ⇒ far fewer/smaller background merges ⇒ much lower memory
+	// pressure — which is what was tripping the server-wide memory limit and
+	// killing inserts. See buildInsertSettings.
+	insertSettings string
 }
 
 // NewCHFromEnv builds a CH from CLICKHOUSE_URL / CLICKHOUSE_DB / CLICKHOUSE_USER /
@@ -61,7 +69,8 @@ func NewCHFromEnv(ctx context.Context) (*CH, error) {
 		client: &http.Client{
 			Timeout: 5 * time.Minute, // post-processing queries can be long
 		},
-		settings: buildCHSettings(),
+		settings:       buildCHSettings(),
+		insertSettings: buildInsertSettings(),
 	}
 	// Retry the ping for ~30s: the worker may boot before ClickHouse is ready
 	// (local compose waits only for "started", not "healthy").
@@ -158,6 +167,24 @@ func buildCHSettings() url.Values {
 	return v
 }
 
+// buildInsertSettings returns the `SETTINGS …` clause embedded in every INSERT.
+//
+// async_insert=1 + wait_for_async_insert=1 tells ClickHouse to buffer incoming
+// rows server-side and flush them as a few large parts, instead of materializing
+// one part per HTTP batch. Under a crawl that fires thousands of small 1000-row
+// inserts from many goroutines at once, this collapses the part count (and the
+// merge/memory pressure that comes with it) by orders of magnitude. wait=1 keeps
+// the call synchronous — we still get a real success/error back, so the caller's
+// retry logic (CHStore) still works and we never "succeed" while dropping data.
+//
+// Disable with CH_ASYNC_INSERT=0 (e.g. to debug or on a CH build without it).
+func buildInsertSettings() string {
+	if os.Getenv("CH_ASYNC_INSERT") == "0" {
+		return ""
+	}
+	return " SETTINGS async_insert=1, wait_for_async_insert=1"
+}
+
 func (c *CH) post(ctx context.Context, query string, body io.Reader) (*http.Response, error) {
 	params := url.Values{"database": {c.db}}
 	for k, vs := range c.settings {
@@ -210,7 +237,7 @@ func (c *CH) InsertJSONEachRow(ctx context.Context, table string, rows []any) er
 			return err
 		}
 	}
-	query := "INSERT INTO " + table + " FORMAT JSONEachRow"
+	query := "INSERT INTO " + table + c.insertSettings + " FORMAT JSONEachRow"
 	resp, err := c.post(ctx, query, &buf)
 	if err != nil {
 		return err

--- a/crawler-go/internal/db/crawldb.go
+++ b/crawler-go/internal/db/crawldb.go
@@ -256,20 +256,34 @@ func (c *CrawlDB) UpdatePage(ctx context.Context, pageID string, sets map[string
 	})
 }
 
-// GetUrlsToCrawl mirrors CrawlDatabase::getUrlsToCrawl.
-func (c *CrawlDB) GetUrlsToCrawl(ctx context.Context, respectRobots bool, limit, maxDepth int) ([]string, error) {
-	sql := "SELECT url FROM pages WHERE crawl_id=$1 AND crawled=false AND external=false AND in_crawl=TRUE"
+// ClaimUrlsToCrawl atomically leases a batch of frontier URLs and returns them.
+//
+// Instead of re-reading the same WHERE crawled=false slice every batch (which got
+// slower as crawled rows piled up in the partition), it stamps claimed_at on the
+// rows it hands out, so the next claim skips them via the idx_pages_frontier
+// partial index — the cost stays O(batch), not O(table). FOR UPDATE SKIP LOCKED
+// lets several drivers pull disjoint batches from the same frontier without
+// double-crawling. A claim older than the lease is reclaimable, so a crawl that
+// died mid-batch (or a quick resume after ResetClaims) never strands URLs.
+func (c *CrawlDB) ClaimUrlsToCrawl(ctx context.Context, respectRobots bool, limit, maxDepth int) ([]string, error) {
+	var sb strings.Builder
+	sb.WriteString(`UPDATE pages SET claimed_at = now() WHERE (crawl_id, id) IN (
+		SELECT crawl_id, id FROM pages
+		WHERE crawl_id=$1 AND crawled=false AND external=false AND in_crawl=TRUE`)
 	if respectRobots {
-		sql += " AND blocked = false"
+		sb.WriteString(" AND blocked = false")
 	}
 	if maxDepth >= 0 {
-		sql += " AND depth = " + strconv.Itoa(maxDepth)
+		sb.WriteString(" AND depth = " + strconv.Itoa(maxDepth))
 	}
-	sql += " ORDER BY id"
+	sb.WriteString(" AND (claimed_at IS NULL OR claimed_at < now() - interval '10 minutes')")
+	sb.WriteString(" ORDER BY id")
 	if limit > 0 {
-		sql += " LIMIT " + strconv.Itoa(limit)
+		sb.WriteString(" LIMIT " + strconv.Itoa(limit))
 	}
-	rows, err := c.pool.Query(ctx, sql, c.CrawlID)
+	sb.WriteString(" FOR UPDATE SKIP LOCKED) RETURNING url")
+
+	rows, err := c.pool.Query(ctx, sb.String(), c.CrawlID)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +297,19 @@ func (c *CrawlDB) GetUrlsToCrawl(ctx context.Context, respectRobots bool, limit,
 		urls = append(urls, u)
 	}
 	return urls, rows.Err()
+}
+
+// ResetClaims clears the claim marker on every still-uncrawled frontier row.
+// Called once when resuming a crawl: a fresh worker must be able to re-lease URLs
+// the previous process had claimed but not yet crawled, without waiting out the
+// 10-minute lease (a worker restart is usually near-instant).
+func (c *CrawlDB) ResetClaims(ctx context.Context) error {
+	return withRetry(ctx, func() error {
+		_, err := c.pool.Exec(ctx,
+			"UPDATE pages SET claimed_at = NULL WHERE crawl_id=$1 AND crawled=false AND claimed_at IS NOT NULL",
+			c.CrawlID)
+		return err
+	})
 }
 
 func (c *CrawlDB) CountUrlsToCrawl(ctx context.Context, respectRobots bool, maxDepth int) (int, error) {
@@ -320,6 +347,28 @@ func (c *CrawlDB) GetCurrentDepth(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return depth, err
+}
+
+// GetStatsSnapshot reads the persisted live counters so the engine can seed its
+// in-memory tallies from the authoritative values (continues correctly on resume
+// and after each end-of-depth UpdateCrawlStats recompute).
+func (c *CrawlDB) GetStatsSnapshot(ctx context.Context) (crawled, compliant, critical, depthMax int64, err error) {
+	err = c.pool.QueryRow(ctx, `
+		SELECT COALESCE(crawled,0), COALESCE(compliant,0), COALESCE(critical_errors,0), COALESCE(depth_max,0)
+		FROM crawls WHERE id=$1`, c.CrawlID).Scan(&crawled, &compliant, &critical, &depthMax)
+	return
+}
+
+// WriteLiveStats writes the engine's running counters to the crawls row with a
+// single cheap UPDATE — no per-call full-partition COUNT(*) scans. This is what
+// keeps the dashboard "URLs crawled" climbing during the walk; the exact
+// aggregates (urls/duplicates/in_progress/response_time) are reconciled by the
+// authoritative UpdateCrawlStats at each end-of-depth and at finish.
+func (c *CrawlDB) WriteLiveStats(ctx context.Context, crawled, compliant, critical, depthMax int64) error {
+	_, err := c.pool.Exec(ctx,
+		"UPDATE crawls SET crawled=$2, compliant=$3, critical_errors=$4, depth_max=$5 WHERE id=$1",
+		c.CrawlID, crawled, compliant, critical, depthMax)
+	return err
 }
 
 // UpdateCrawlStats recomputes the aggregate stats on the crawls row.

--- a/crawler-go/internal/db/crawldb.go
+++ b/crawler-go/internal/db/crawldb.go
@@ -308,9 +308,13 @@ func (c *CrawlDB) GetCrawledCount(ctx context.Context) int {
 
 func (c *CrawlDB) GetCurrentDepth(ctx context.Context) (int, error) {
 	var depth int
+	// Resume must continue from the LOWEST unfinished depth so the walk stays
+	// breadth-first. Without ORDER BY, PG returns an arbitrary uncrawled row, so
+	// a resume could jump to depth N+1 while depth N still had pending URLs.
 	err := c.pool.QueryRow(ctx, `
 		SELECT depth FROM pages
 		WHERE crawl_id=$1 AND crawled=false AND external=false AND blocked=false AND in_crawl=TRUE
+		ORDER BY depth ASC
 		LIMIT 1`, c.CrawlID).Scan(&depth)
 	if err == pgx.ErrNoRows {
 		return 0, nil

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -27,7 +27,8 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24-alpine
     # CH 24 borne son max_server_memory_usage sur ce cgroup → pas de creep RAM.
-    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-4g}
+    # Fallback 6g (autosize.sh le surcharge à ~30% de la RAM hôte via start.sh).
+    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-6g}
     cpu_shares: 2048 # interactif (sert les rapports)
     ports:
       - "8123:8123"  # HTTP interface (lectures rapports + writes crawler)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,9 @@ services:
     # ClickHouse 24 détecte le cgroup memory.max et borne automatiquement son
     # max_server_memory_usage (~90%), donc ce mem_limit suffit à l'empêcher de
     # grignoter toute la RAM via les merges/cache de requêtes sur la durée.
-    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-4g}
+    # Fallback à 6g (CH = service le plus lourd, source de vérité des données) ;
+    # autosize.sh le remplace par ~30% de la RAM hôte quand start.sh est utilisé.
+    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-6g}
     # Interactif (sert les rapports PHP). Le travail background du crawler dans CH
     # est déjà rendu "nice" au niveau threads (os_thread_priority, voir crawler-go),
     # donc le conteneur garde un poids élevé pour ne pas pénaliser les rapports.

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -368,6 +368,7 @@ CREATE TABLE pages (
     word_count INTEGER DEFAULT 0,
     in_crawl BOOLEAN DEFAULT TRUE,
     in_sitemap BOOLEAN DEFAULT FALSE,
+    claimed_at TIMESTAMP, -- frontier lease marker (ClaimUrlsToCrawl); NULL = unclaimed
     generation JSONB,
     PRIMARY KEY (crawl_id, id)
 ) PARTITION BY LIST (crawl_id);
@@ -376,6 +377,12 @@ CREATE TABLE pages (
 CREATE INDEX idx_pages_in_sitemap ON pages (crawl_id, in_sitemap) WHERE in_sitemap = TRUE;
 CREATE INDEX idx_pages_not_in_crawl ON pages (crawl_id, in_crawl) WHERE in_crawl = FALSE;
 CREATE INDEX idx_pages_generation_gin ON pages USING GIN (generation);
+-- Frontier queue index: keeps the uncrawled-URL lease (ClaimUrlsToCrawl) and the
+-- end-of-depth count O(remaining frontier) instead of O(whole partition). The
+-- partial predicate means crawled rows leave the index, so it shrinks as the crawl
+-- advances — the fix for the freeze on multi-million-URL crawls.
+CREATE INDEX idx_pages_frontier ON pages (crawl_id, depth, claimed_at, id)
+    WHERE crawled = false AND external = false AND in_crawl = true;
 
 -- Table links partitionnée par crawl_id
 -- Pas de PRIMARY KEY volontairement : on stocke TOUS les <a> tels qu'ils

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -115,7 +115,10 @@ CREATE TABLE crawls (
     -- le crawler Go au démarrage du crawl quand ClickHouse est actif ; route les lectures.
     data_store VARCHAR(16) DEFAULT 'pg' CHECK (data_store IN ('pg', 'clickhouse')),
     -- Nombre d'erreurs critiques (timeouts/erreurs réseau) rencontrées pendant le crawl.
-    critical_errors INTEGER DEFAULT 0
+    critical_errors INTEGER DEFAULT 0,
+    -- Score santé SEO 0-100 calculé depuis ClickHouse et persisté (App\Analysis\CrawlStats).
+    -- NULL = pas encore calculé (sentinelle du write-through home/page projet).
+    health_score SMALLINT
 );
 
 CREATE INDEX idx_crawls_path ON crawls(path);
@@ -588,5 +591,6 @@ INSERT INTO migrations (name) VALUES
     ('2026-05-24-09-00-crawl-data-store'),
     ('2026-05-24-16-00-crawl-critical-errors'),
     ('2026-05-25-10-00-report-precompute-cache'),
-    ('2026-05-25-12-00-report-cache-query-columns')
+    ('2026-05-25-12-00-report-cache-query-columns'),
+    ('2026-05-27-12-00-crawl-health-score')
 ON CONFLICT (name) DO NOTHING;

--- a/migrations/2026-05-27-12-00-crawl-health-score.php
+++ b/migrations/2026-05-27-12-00-crawl-health-score.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Migration : colonne `health_score` sur la table `crawls`.
+ *
+ * Score santé SEO (0-100) calculé une fois depuis ClickHouse et persisté
+ * (cf. App\Analysis\CrawlStats). NULL = pas encore calculé (sentinelle du
+ * write-through : tant qu'il est NULL, la home/page projet le calcule en live
+ * puis le stocke ; ensuite lecture directe de la ligne, zéro requête CH).
+ * Idempotent (ADD COLUMN IF NOT EXISTS).
+ */
+$pdo = \App\Database\PostgresDatabase::getInstance()->getConnection();
+
+try {
+    $pdo->exec("ALTER TABLE crawls ADD COLUMN IF NOT EXISTS health_score SMALLINT");
+    echo "(added health_score to crawls) ";
+    return true;
+} catch (\Exception $e) {
+    echo "Error: " . $e->getMessage();
+    return false;
+}

--- a/migrations/2026-05-27-12-00-frontier-queue-index.php
+++ b/migrations/2026-05-27-12-00-frontier-queue-index.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Migration: file d'attente frontier robuste pour les très gros crawls.
+ *
+ * Ajoute pages.claimed_at (marqueur de lease posé par ClaimUrlsToCrawl côté
+ * crawler Go) et un index partiel idx_pages_frontier. Avant, le crawler relisait à
+ * chaque batch la tranche `WHERE crawled=false ... ORDER BY id` sans index
+ * composite : le coût croissait avec la taille de la partition (O(N) par batch →
+ * O(N²) sur le crawl), d'où le gel observé sur des sites à plusieurs millions
+ * d'URL. L'index partiel ne contient que le frontier restant (les lignes crawlées
+ * en sortent), donc le lease ET le COUNT de fin de profondeur redeviennent
+ * O(frontier restant) au lieu de O(partition entière).
+ *
+ * pages est partitionnée par LIST(crawl_id) : ALTER TABLE / CREATE INDEX sur le
+ * parent se propage à toutes les partitions existantes et futures. Idempotent.
+ */
+$pdo = \App\Database\PostgresDatabase::getInstance()->getConnection();
+
+try {
+    $pdo->exec("ALTER TABLE pages ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMP");
+    echo "(added pages.claimed_at) ";
+
+    $pdo->exec("
+        CREATE INDEX IF NOT EXISTS idx_pages_frontier ON pages (crawl_id, depth, claimed_at, id)
+        WHERE crawled = false AND external = false AND in_crawl = true
+    ");
+    echo "(created idx_pages_frontier) ";
+
+    return true;
+} catch (\Exception $e) {
+    echo "Error: " . $e->getMessage();
+    return false;
+}

--- a/scouter.php
+++ b/scouter.php
@@ -105,6 +105,11 @@ switch($module){
                 \App\Analysis\ReportPrecompute::recomputeProject($id);
             } else {
                 \App\Analysis\ReportPrecompute::recompute($id);
+                // Stats de crawl persistées (compliant + critical_errors + health_score)
+                // calculées depuis ClickHouse, une fois, à la fin du crawl → la home et
+                // la page projet n'ont plus à les calculer en live. Le score n'étant pas
+                // dépendant des catégories, on ne le refait PAS au precompute-reports-project.
+                \App\Analysis\CrawlStats::ensureFromClickHouse([$id]);
             }
         }
         $jobId = getenv('JOB_ID');

--- a/web/components/project-metrics.php
+++ b/web/components/project-metrics.php
@@ -27,57 +27,11 @@ if (!function_exists('pcHealthScore')) {
     }
 }
 
-if (!function_exists('chHealthScores')) {
-    /**
-     * Score de santé SEO 0-100 PAR crawl, calculé en direct dans ClickHouse —
-     * 5 piliers équipondérés : (1) indexabilité, (2) on-page (title+h1 uniques),
-     * (3) contenu non-thin (>500 mots), (4) distribution du PageRank interne vers
-     * les pages conformes, (5) profondeur ≤ seuil géométrique (arbre en base 5).
-     * UNE seule requête batchée pour tous les crawls passés. Retourne
-     * [crawl_id => int]. Vide si ClickHouse est désactivé OU pour un crawl pas
-     * encore migré (absent de CH) → l'appelant retombe alors sur pcHealthScore.
-     * (Le seul calcul de score qui touche CH au rendu ; le reste reste pur-PHP.)
-     */
-    function chHealthScores(array $crawlIds): array {
-        $crawlIds = array_values(array_unique(array_filter(array_map('intval', $crawlIds))));
-        if (empty($crawlIds) || !\App\Database\ClickHouseDatabase::enabled()) return [];
-        $idList = implode(',', $crawlIds);
-        // pages est ReplacingMergeTree → on déduplique (LIMIT 1 BY crawl_id,id) avant
-        // d'agréger ; title_status/h1_status/pri vivent dans page_metrics (dérivé).
-        $sql = "
-WITH per AS (
-  SELECT crawl_id, countIf(compliant=1 AND is_html=1) AS idx
-  FROM (SELECT crawl_id, id, compliant, is_html FROM pages WHERE crawl_id IN ($idList)
-        ORDER BY date DESC LIMIT 1 BY crawl_id, id)
-  GROUP BY crawl_id
-),
-thr AS (SELECT crawl_id, greatest(ceil(log((idx + 24) / 25.0) / log(5.0)), 1) AS max_depth FROM per)
-SELECT p.crawl_id AS crawl_id,
-  round((
-      countIf(p.compliant=1 AND p.is_html=1)*100.0 / nullIf(countIf(p.crawled=1 AND p.is_html=1),0)
-    + countIf(m.title_status='unique' AND m.h1_status='unique' AND p.compliant=1 AND p.is_html=1)*100.0 / nullIf(countIf(p.crawled=1 AND p.is_html=1),0)
-    + countIf(p.compliant=1 AND p.is_html=1 AND p.word_count>500)*100.0 / nullIf(countIf(p.compliant=1 AND p.is_html=1),0)
-    + sumIf(m.pri, p.compliant=1 AND p.is_html=1)*100.0 / nullIf(sum(m.pri),0)
-    + countIf(p.compliant=1 AND p.is_html=1 AND p.depth <= t.max_depth)*100.0 / nullIf(countIf(p.compliant=1 AND p.is_html=1),0)
-  ) / 5) AS score
-FROM (SELECT crawl_id, id, compliant, is_html, crawled, word_count, depth FROM pages WHERE crawl_id IN ($idList)
-      ORDER BY date DESC LIMIT 1 BY crawl_id, id) p
-LEFT JOIN page_metrics m ON m.crawl_id = p.crawl_id AND m.id = p.id
-JOIN thr t ON t.crawl_id = p.crawl_id
-GROUP BY p.crawl_id, t.max_depth";
-        $out = [];
-        try {
-            foreach (\App\Database\ClickHouseDatabase::getInstance()->select($sql) as $r) {
-                if (($r['score'] ?? null) !== null && $r['score'] !== '') {
-                    $out[(int)$r['crawl_id']] = (int)round(max(0, min(100, (float)$r['score'])));
-                }
-            }
-        } catch (\Throwable $e) {
-            error_log('chHealthScores CH query failed: ' . $e->getMessage());
-        }
-        return $out;
-    }
-}
+// NB : le calcul du score santé 5 piliers (et compliant/critical_errors) en
+// ClickHouse vit désormais dans App\Analysis\CrawlStats::ensureFromClickHouse()
+// — calculé UNE fois puis persisté dans la ligne crawls (write-through). La home
+// et la page projet lisent stats['health_score'] (repli pcHealthScore ci-dessous
+// si jamais absent). Plus de calcul live à chaque rendu.
 
 if (!function_exists('pcScoreColor')) {
     function pcScoreColor(int $score): string {

--- a/web/index.php
+++ b/web/index.php
@@ -65,7 +65,9 @@ function processCrawlsForProject($project, $crawls, $jobManager) {
                 'compliant' => $crawl->compliant,
                 'duplicates' => $crawl->duplicates ?? 0,
                 'critical_errors' => $crawl->critical_errors ?? 0,
-                'response_time' => $crawl->response_time ?? 0
+                'response_time' => $crawl->response_time ?? 0,
+                // null = pas encore calculé (sentinelle write-through CrawlStats)
+                'health_score' => isset($crawl->health_score) ? (int)$crawl->health_score : null
             ],
             "job_status" => $jobStatus,
             "in_progress" => $crawl->in_progress ?? 0,
@@ -263,53 +265,41 @@ try {
     }
     unset($p);
     
-    // Erreurs critiques (pages 4xx/5xx) : UNE seule requête ClickHouse pour tous
-    // les crawls affichés, comptées à l'affichage (comme un KPI normal), injectées
-    // dans chaque crawl. Pas de colonne, pas de script.
-    $allCrawlIds = [];
+    // Stats dérivées (pages indexables + erreurs critiques + score santé) : write-through.
+    // On NE calcule en live QUE les crawls dont health_score n'est pas encore stocké
+    // (sentinelle NULL) ; les autres sont lus directement de la ligne crawls → zéro
+    // requête ClickHouse. La passe CH (App\Analysis\CrawlStats) calcule les 3 d'un coup
+    // ET les persiste, donc au fil des visites tout se remplit et la home devient
+    // instantanée. Les nouveaux crawls sont déjà pré-remplis au post-crawl (scouter.php).
+    require_once(__DIR__ . '/components/project-metrics.php');
+    $needIds = [];
     foreach ([$myProjects, $sharedProjects, $otherProjects] as $list) {
         foreach ($list as $p) {
-            foreach (($p->crawls ?? []) as $c) { $allCrawlIds[(int)$c->crawl_id] = true; }
-        }
-    }
-    if (!empty($allCrawlIds) && \App\Database\ClickHouseDatabase::enabled()) {
-        try {
-            $idList = implode(',', array_map('intval', array_keys($allCrawlIds)));
-            $critRows = \App\Database\ClickHouseDatabase::getInstance()->select(
-                "SELECT crawl_id, countDistinct(id) AS n FROM pages
-                 WHERE crawl_id IN ($idList) AND code >= 400 AND crawled = 1
-                 GROUP BY crawl_id"
-            );
-            $critMap = [];
-            foreach ($critRows as $cr) { $critMap[(int)$cr['crawl_id']] = (int)$cr['n']; }
-            foreach ([$myProjects, $sharedProjects, $otherProjects] as $list) {
-                foreach ($list as $p) {
-                    foreach (($p->crawls ?? []) as $c) {
-                        $stats = $c->stats;
-                        $stats['critical_errors'] = $critMap[(int)$c->crawl_id] ?? 0;
-                        $c->stats = $stats;
-                    }
-                }
+            foreach (($p->crawls ?? []) as $c) {
+                if (($c->stats['health_score'] ?? null) === null) { $needIds[(int)$c->crawl_id] = true; }
             }
-        } catch (\Throwable $e) {
-            error_log("critical_errors CH query failed: " . $e->getMessage());
         }
     }
-
-    // Score de santé SEO (5 piliers) calculé dans ClickHouse pour tous les crawls
-    // affichés, injecté par crawl. Repli sur pcHealthScore (pur PHP) pour les
-    // crawls absents de CH (non migrés) — voir project-card.php.
-    require_once(__DIR__ . '/components/project-metrics.php');
-    $healthMap = chHealthScores(array_keys($allCrawlIds));
-    if (!empty($healthMap)) {
+    if (!empty($needIds)) {
+        $computed = \App\Analysis\CrawlStats::ensureFromClickHouse(array_keys($needIds));
         foreach ([$myProjects, $sharedProjects, $otherProjects] as $list) {
             foreach ($list as $p) {
                 foreach (($p->crawls ?? []) as $c) {
-                    if (isset($healthMap[(int)$c->crawl_id])) {
-                        $stats = $c->stats;
-                        $stats['health_score'] = $healthMap[(int)$c->crawl_id];
-                        $c->stats = $stats;
+                    if (($c->stats['health_score'] ?? null) !== null) { continue; }
+                    $id = (int)$c->crawl_id;
+                    $stats = $c->stats;
+                    if (isset($computed[$id])) {
+                        $stats['compliant'] = $computed[$id]['compliant'];
+                        $stats['critical_errors'] = $computed[$id]['critical_errors'];
+                        $stats['health_score'] = $computed[$id]['health_score'];
+                    } else {
+                        // crawl absent de ClickHouse → repli pcHealthScore (pur PHP, gratuit)
+                        // + on fige la sentinelle pour ne plus retenter à chaque visite.
+                        $fallback = pcHealthScore($stats);
+                        $stats['health_score'] = $fallback;
+                        \App\Analysis\CrawlStats::persistHealthScore($id, $fallback);
                     }
+                    $c->stats = $stats;
                 }
             }
         }

--- a/web/project.php
+++ b/web/project.php
@@ -45,6 +45,8 @@ foreach ($projectCrawls as $crawl) {
             'urls' => $crawl->urls ?? 0, 'crawled' => $crawl->crawled ?? 0, 'compliant' => $crawl->compliant ?? 0,
             'duplicates' => $crawl->duplicates ?? 0, 'critical_errors' => $crawl->critical_errors ?? 0,
             'response_time' => $crawl->response_time ?? 0, 'depth_max' => $crawl->depth_max ?? 0,
+            // null = pas encore calculé (sentinelle write-through CrawlStats)
+            'health_score' => isset($crawl->health_score) ? (int)$crawl->health_score : null,
         ],
         'job_status' => $jobStatus, 'in_progress' => $crawl->in_progress ?? 0,
         'config' => json_decode($crawl->config ?? '{}', true), 'crawl_type' => $crawl->crawl_type ?? 'spider',
@@ -53,32 +55,33 @@ foreach ($projectCrawls as $crawl) {
 }
 usort($crawls, fn($a, $b) => $b->crawl_id - $a->crawl_id);
 
-// Erreurs critiques (4xx/5xx) : une requête ClickHouse pour tous les crawls.
-if (!empty($crawls) && \App\Database\ClickHouseDatabase::enabled()) {
-    try {
-        $idList = implode(',', array_map(fn($c) => (int)$c->crawl_id, $crawls));
-        $critRows = \App\Database\ClickHouseDatabase::getInstance()->select(
-            "SELECT crawl_id, countDistinct(id) AS n FROM pages
-             WHERE crawl_id IN ($idList) AND code >= 400 AND crawled = 1 GROUP BY crawl_id"
-        );
-        $critMap = [];
-        foreach ($critRows as $cr) { $critMap[(int)$cr['crawl_id']] = (int)$cr['n']; }
-        foreach ($crawls as $c) {
-            $s = $c->stats; $s['critical_errors'] = $critMap[(int)$c->crawl_id] ?? 0; $c->stats = $s;
-        }
-    } catch (\Throwable $e) { error_log("project critical_errors CH: " . $e->getMessage()); }
-}
-
 require_once(__DIR__ . '/components/project-metrics.php');
 
-// Score de santé SEO (5 piliers) calculé dans ClickHouse pour tous les crawls,
-// injecté par crawl. Repli sur pcHealthScore (pur PHP) si crawl absent de CH.
-$healthMap = chHealthScores(array_map(fn($c) => (int)$c->crawl_id, $crawls));
-if (!empty($healthMap)) {
+// Stats dérivées (pages indexables + erreurs critiques + score santé) : write-through.
+// On NE calcule en live QUE les crawls dont health_score n'est pas encore stocké
+// (sentinelle NULL) ; les autres sont lus directement de la ligne crawls → zéro
+// requête ClickHouse. La passe CH calcule les 3 d'un coup ET les persiste.
+$needIds = [];
+foreach ($crawls as $c) {
+    if (($c->stats['health_score'] ?? null) === null) { $needIds[(int)$c->crawl_id] = true; }
+}
+if (!empty($needIds)) {
+    $computed = \App\Analysis\CrawlStats::ensureFromClickHouse(array_keys($needIds));
     foreach ($crawls as $c) {
-        if (isset($healthMap[(int)$c->crawl_id])) {
-            $s = $c->stats; $s['health_score'] = $healthMap[(int)$c->crawl_id]; $c->stats = $s;
+        if (($c->stats['health_score'] ?? null) !== null) { continue; }
+        $id = (int)$c->crawl_id;
+        $s = $c->stats;
+        if (isset($computed[$id])) {
+            $s['compliant'] = $computed[$id]['compliant'];
+            $s['critical_errors'] = $computed[$id]['critical_errors'];
+            $s['health_score'] = $computed[$id]['health_score'];
+        } else {
+            // crawl absent de ClickHouse → repli pcHealthScore (gratuit) + fige la sentinelle.
+            $fallback = pcHealthScore($s);
+            $s['health_score'] = $fallback;
+            \App\Analysis\CrawlStats::persistHealthScore($id, $fallback);
         }
+        $c->stats = $s;
     }
 }
 


### PR DESCRIPTION
## Summary

This branch fixes scalability and UX issues that surfaced on large crawls (~300 crawls / 1.5M pages and the infinite-URL test site).

- **Stop multi-million-URL crawls from freezing the worker.** Per-batch bookkeeping cost `O(whole partition)` instead of `O(batch)`, turning the BFS walk into `O(N²)` on the single crawl-driver goroutine. Crawls looked "running" while the crawled count stalled, and stop signals were ignored.
- **Resume from the lowest unfinished depth.** `GetCurrentDepth` selected the resume depth with `LIMIT 1` and no `ORDER BY`, so resume could jump to a deeper level while a shallower one still had pending URLs, breaking breadth-first ordering.
- **Speed up the homepage and project pages.** The 5-pillar SEO health score was recomputed live in ClickHouse for every displayed crawl on every load (page dedup + JOIN over the full page set), plus a live `critical_errors` query — slow at scale.

## Details

### Crawler scalability
1. **Incremental live stats** — the driver no longer fires `UpdateCrawlStats` (8 full-partition scans) every 10s / render batch. The engine keeps in-memory counters seeded from the authoritative row and persisted by a background writer; exact aggregates are reconciled only at end-of-depth and finish.
2. **Frontier partial index** — `idx_pages_frontier` keeps the lease and end-of-depth count `O(remaining frontier)`; crawled rows leave the index so it shrinks as the crawl advances.
3. **Control logic off the hot path** — a 2s stop-poller refreshes an atomic flag instead of a status query per URL; the stats writer runs on its own goroutine; frontier claim/count run under a 60s timeout so a pathological scan is cancelled instead of wedging the driver.
4. **Frontier as a lease queue** — `ClaimUrlsToCrawl` stamps `claimed_at` via `FOR UPDATE SKIP LOCKED` + `RETURNING`, so batches skip leased rows and multiple drivers can pull disjoint work. A 10-minute lease + `ResetClaims` on resume keep URLs from being stranded.

### Home / project performance (write-through health score)
- New column `crawls.health_score SMALLINT` (`NULL` = sentinel, not yet computed).
- `App\Analysis\CrawlStats::ensureFromClickHouse()` runs one batched CH query yielding `compliant` + `critical_errors` + `health_score` per crawl and persists them. Single source of the 5-pillar SQL.
- New crawls compute it post-crawl in the precompute-reports job; old crawls compute live only while `health_score` is `NULL`, then write through. Crawls absent from CH fall back to pure-PHP scoring. The home fills in gradually and becomes a plain row read (zero CH query at render).
- Migration is idempotent (`ADD COLUMN IF NOT EXISTS`) and runs automatically at deploy.