### PR TITLE
feat(mcp): open MCP & API to all roles (permissions enforced) + fix report precache on API categorization

### DIFF
--- a/app/Http/Controllers/ApiKeyController.php
+++ b/app/Http/Controllers/ApiKeyController.php
@@ -7,8 +7,13 @@ use App\Http\Request;
 use App\Api\ApiKeyService;
 
 /**
- * Admin-only management of personal API keys (session-authenticated, called by
- * the Settings page). Distinct from the public token API (/api/v1/*).
+ * Self-service management of personal API keys (session-authenticated, called
+ * by the Settings page). Available to EVERY logged-in user regardless of role.
+ * Distinct from the public token API (/api/v1/*).
+ *
+ * Every operation is scoped to the caller via $this->userId, so a user can only
+ * ever see, create or revoke their OWN keys — never another user's. The issued
+ * token then acts strictly within its owner's role/permissions on /api/v1.
  *
  * The plaintext token is returned ONLY by create(); afterwards only metadata
  * (name, prefix, dates) is ever exposed.
@@ -18,13 +23,13 @@ use App\Api\ApiKeyService;
  */
 class ApiKeyController extends Controller
 {
-    /** GET /api/keys — list the current admin's active keys (metadata only). */
+    /** GET /api/keys — list the current user's active keys (metadata only). */
     public function index(Request $request): void
     {
         $this->success(['keys' => ApiKeyService::listForUser((int)$this->userId)]);
     }
 
-    /** POST /api/keys — create a key; returns the plaintext token ONCE. */
+    /** POST /api/keys — create a key for the current user; returns the plaintext token ONCE. */
     public function create(Request $request): void
     {
         $name = trim((string)$request->get('name', ''));
@@ -38,7 +43,7 @@ class ApiKeyController extends Controller
         ], 'API key created — copy it now, it will not be shown again.');
     }
 
-    /** DELETE /api/keys/{id} — revoke one of the admin's keys. */
+    /** DELETE /api/keys/{id} — revoke one of the current user's own keys. */
     public function revoke(Request $request): void
     {
         $id = (int)$request->param('id', 0);

--- a/app/Http/Controllers/ApiV1Controller.php
+++ b/app/Http/Controllers/ApiV1Controller.php
@@ -588,6 +588,36 @@ class ApiV1Controller extends Controller
             }
         }
 
+        // Refresh the precomputed report fragments that depend on categories
+        // (category distribution, Sankey flow, external links by category…). These
+        // live in crawl_report_cache and are NOT recomputed by the categorization
+        // apply itself — without this step the reports keep showing the OLD
+        // categories after a save via the API/MCP, exactly as they do from the UI
+        // save flow (CategorizationController::save). Mirror that routine here:
+        //   - synchronous recompute of THIS crawl so the reports the caller looks
+        //     at right after are fresh (reads the live category we just persisted),
+        //   - an async project-wide job for the other crawls. It is queued AFTER
+        //     the batch-categorize job above so that, by the time it runs, every
+        //     crawl's per-crawl YAML snapshot has been refreshed (the CH live
+        //     `category` reads that snapshot) — otherwise the others would be
+        //     recomputed against their stale categories.
+        $reportPrecomputeJobId = null;
+        try {
+            \App\Analysis\ReportPrecompute::recompute($cid, true); // category-dependent fragments only
+        } catch (\Throwable $e) {
+            error_log('[API categorization] report precompute on crawl ' . $cid . ' failed: ' . $e->getMessage());
+        }
+        if ($deployToProject && $otherCrawls > 0) {
+            try {
+                $pjm = new JobManager();
+                $reportPrecomputeJobId = $pjm->createJob((string)($crawl->path ?? ''), 'Report Precompute', "precompute-reports-project:{$projectId}");
+                $pjm->updateJobStatus($reportPrecomputeJobId, 'queued');
+                $pjm->addLog($reportPrecomputeJobId, "Queued report recompute for the project after categorization via API (crawl #{$cid} recomputed synchronously).", 'info');
+            } catch (\Throwable $e) {
+                error_log('[API categorization] queue project report precompute failed: ' . $e->getMessage());
+            }
+        }
+
         $payload = [
             'crawl_id'          => $cid,
             'project_id'        => $projectId,
@@ -598,6 +628,12 @@ class ApiV1Controller extends Controller
                 'job_id'       => $jobId !== null ? (int)$jobId : null,
                 'progress'     => $jobId !== null ? 0 : 100,
                 'other_crawls' => $otherCrawls,
+            ],
+            // Report fragments are refreshed so the reports immediately reflect the
+            // new categories (this crawl synchronously, the rest in the background).
+            'report_precompute' => [
+                'current_crawl'  => 'completed',
+                'project_job_id' => $reportPrecomputeJobId !== null ? (int)$reportPrecomputeJobId : null,
             ],
         ];
         // Config is persisted regardless; surface a sync-apply failure so the

--- a/tests/Unit/ApiKeyAccessTest.php
+++ b/tests/Unit/ApiKeyAccessTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Guard tests for the authorization options declared on the REST routes in
+ * web/api/index.php.
+ *
+ * The MCP & public API are meant to be usable by EVERY authenticated user
+ * (each acting strictly within their own role/permissions). Personal API-key
+ * management (/keys) was opened from admin-only to any logged-in user, while
+ * genuinely administrative surfaces (/users, /settings) MUST stay admin-only.
+ *
+ * These tests parse the route table statically (no DB) so a regression that
+ * re-locks key management — or accidentally unlocks user/settings management —
+ * fails loudly.
+ */
+
+/** Extract the options array literal declared for a given METHOD + path. */
+function routeOptionsFor(string $routes, string $method, string $path): ?string
+{
+    // Matches e.g. $router->get('/keys', [Ctrl::class, 'm'], ['auth' => true]);
+    $p = preg_quote($path, '#');
+    $re = '#\$router->' . strtolower($method) . '\(\s*\'' . $p . '\'\s*,\s*\[[^\]]*\]\s*,\s*(\[[^\]]*\])\s*\)#';
+    return preg_match($re, $routes, $m) ? $m[1] : null;
+}
+
+beforeEach(function () {
+    // The route table is plain source we assert against (no DB needed).
+    $this->routes = file_get_contents(__DIR__ . '/../../web/api/index.php');
+});
+
+describe('API key management routes — open to all authenticated users', function () {
+
+    it('GET /keys requires auth but is NOT admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'get', '/keys');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'auth' => true");
+        expect($opts)->not->toContain("'admin' => true");
+    });
+
+    it('POST /keys requires auth but is NOT admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'post', '/keys');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'auth' => true");
+        expect($opts)->not->toContain("'admin' => true");
+    });
+
+    it('DELETE /keys/{id} requires auth but is NOT admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'delete', '/keys/{id}');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'auth' => true");
+        expect($opts)->not->toContain("'admin' => true");
+    });
+});
+
+describe('Administrative routes stay admin-only (regression guard)', function () {
+
+    it('GET /users is still admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'get', '/users');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'admin' => true");
+    });
+
+    it('POST /users is still admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'post', '/users');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'admin' => true");
+    });
+
+    it('GET /settings is still admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'get', '/settings');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'admin' => true");
+    });
+
+    it('POST /settings/budget is still admin-only', function () {
+        $opts = routeOptionsFor($this->routes, 'post', '/settings/budget');
+        expect($opts)->not->toBeNull();
+        expect($opts)->toContain("'admin' => true");
+    });
+});
+
+describe('Public API v1 stays Bearer-token authenticated (no session, no admin gate)', function () {
+
+    it('every /v1/ route is declared with the token guard', function () {
+        // Pull every $router->verb('/v1/...', ..., [opts]) line and check opts.
+        preg_match_all(
+            '#\$router->\w+\(\s*\'(/v1/[^\']*)\'\s*,\s*\[[^\]]*\]\s*,\s*(\[[^\]]*\])\s*\)#',
+            $this->routes,
+            $m,
+            PREG_SET_ORDER
+        );
+        expect(count($m))->toBeGreaterThan(0);
+        foreach ($m as $route) {
+            [$_, $path, $opts] = $route;
+            // Every public API route is Bearer-token authenticated…
+            expect($opts)->toContain("'token' => true");
+            // …and never also locked behind a cookie-session admin gate.
+            expect($opts)->not->toContain("'admin' => true");
+        }
+    });
+});

--- a/tests/Unit/ApiKeyServiceTest.php
+++ b/tests/Unit/ApiKeyServiceTest.php
@@ -86,3 +86,31 @@ it('stamps last_used_at on first use (null → set)', function () {
     $after = $this->db->query("SELECT last_used_at FROM api_keys WHERE id = " . (int)$g['id'])->fetchColumn();
     expect($after)->not->toBeNull();
 });
+
+// Non-admin users can mint keys too — the issued key carries the OWNER's role,
+// so downstream /api/v1 role checks keep a viewer strictly read-only and a user
+// scoped to their own + shared projects. This proves key creation is not
+// admin-gated at the service level and never escalates privileges.
+it('lets non-admin roles generate keys that carry the owner role unchanged', function () {
+    foreach (['user', 'viewer'] as $role) {
+        $email = 'apikey-' . $role . '-' . uniqid() . '@example.test';
+        $this->db->prepare("INSERT INTO users (email, password_hash, role) VALUES (:e, 'x', :r)")
+            ->execute([':e' => $email, ':r' => $role]);
+        $rid = (int)$this->db->query("SELECT id FROM users WHERE email = " . $this->db->quote($email))->fetchColumn();
+
+        try {
+            $g = ApiKeyService::generate($rid, $role . ' key');
+            expect($g['token'])->toStartWith('sctr_');
+
+            $v = ApiKeyService::verify($g['token']);
+            expect($v)->not->toBeNull();
+            expect((int)$v['user']->id)->toBe($rid);
+            // The role embedded in the verified context is the owner's — never
+            // promoted to admin just because a key exists.
+            expect($v['user']->role)->toBe($role);
+        } finally {
+            $this->db->exec("DELETE FROM api_keys WHERE user_id = " . $rid);
+            $this->db->prepare("DELETE FROM users WHERE id = :id")->execute([':id' => $rid]);
+        }
+    }
+});

--- a/tests/Unit/OAuthServerTest.php
+++ b/tests/Unit/OAuthServerTest.php
@@ -94,6 +94,39 @@ it('exchanges an auth code for a working sctr_ access token', function () {
     expect((int) $verified['user']->id)->toBe($this->uid);
 });
 
+it('issues a token that preserves a read-only viewer role (no privilege escalation)', function () {
+    // A viewer must be able to connect the MCP connector, but the resulting key
+    // must keep acting as a viewer downstream — never gain write access.
+    $email = 'oauth-viewer-' . uniqid() . '@example.test';
+    $this->db->prepare("INSERT INTO users (email, password_hash, role) VALUES (:e, 'x', 'viewer')")
+        ->execute([':e' => $email]);
+    $vid = (int) $this->db->query("SELECT id FROM users WHERE email = " . $this->db->quote($email))->fetchColumn();
+
+    try {
+        $reg = registerPestClient();
+        $redirect = 'https://claude.ai/api/mcp/auth_callback';
+        $code = OAuthServer::issueCode($reg['client_id'], $vid, $redirect, $this->challenge, 'mcp');
+
+        $res = OAuthServer::exchangeCode([
+            'grant_type'    => 'authorization_code',
+            'code'          => $code,
+            'redirect_uri'  => $redirect,
+            'client_id'     => $reg['client_id'],
+            'code_verifier' => $this->verifier,
+        ]);
+        expect($res['access_token'])->toStartWith('sctr_');
+
+        $verified = ApiKeyService::verify($res['access_token']);
+        expect($verified)->not->toBeNull();
+        expect((int) $verified['user']->id)->toBe($vid);
+        expect($verified['user']->role)->toBe('viewer');
+    } finally {
+        $this->db->exec("DELETE FROM oauth_auth_codes WHERE user_id = " . $vid);
+        $this->db->exec("DELETE FROM api_keys WHERE user_id = " . $vid);
+        $this->db->prepare("DELETE FROM users WHERE id = :id")->execute([':id' => $vid]);
+    }
+});
+
 it('rejects a code exchange with a bad PKCE verifier', function () {
     $reg = registerPestClient();
     $redirect = 'https://claude.ai/api/mcp/auth_callback';

--- a/tests/Unit/ReportPrecomputeTest.php
+++ b/tests/Unit/ReportPrecomputeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Analysis\ReportPrecompute;
+use App\Database\PostgresDatabase;
+
+/**
+ * Tests for the report-precompute refresh routine that keeps the precomputed,
+ * category-dependent report fragments (crawl_report_cache) in sync after a
+ * categorization change.
+ *
+ * Regression context: saving a categorization from the API/MCP
+ * (ApiV1Controller::setCategorization) used to skip this routine entirely, so
+ * the reports kept rendering the OLD categories. These tests pin down both that
+ * the routine actually rewrites a stored fragment, and that the API path now
+ * invokes it (mirroring the UI save flow).
+ *
+ * DB-backed (Postgres). ClickHouse is disabled in tests, so recompute uses the
+ * PG report shim — we keep the stored query off the `pages` table so it needs
+ * no partitions.
+ */
+
+beforeEach(function () {
+    $this->db = PostgresDatabase::getInstance()->getConnection();
+
+    $this->email = 'precompute-' . uniqid() . '@example.test';
+    $this->db->prepare("INSERT INTO users (email, password_hash, role) VALUES (:e, 'x', 'admin')")
+        ->execute([':e' => $this->email]);
+    $this->uid = (int) $this->db->query("SELECT id FROM users WHERE email = " . $this->db->quote($this->email))->fetchColumn();
+
+    $this->pid = (int) $this->db->query(
+        "INSERT INTO projects (user_id, name) VALUES ({$this->uid}, 'precompute-proj') RETURNING id"
+    )->fetchColumn();
+
+    $this->cid = (int) $this->db->query(
+        "INSERT INTO crawls (project_id, domain, path, status, config)
+         VALUES ({$this->pid}, 'precompute.test', 'precompute-test-{$this->pid}', 'finished', '{}') RETURNING id"
+    )->fetchColumn();
+});
+
+afterEach(function () {
+    $this->db->exec("DELETE FROM crawl_report_cache WHERE crawl_id = " . (int) $this->cid);
+    $this->db->exec("DELETE FROM crawl_categories WHERE project_id = " . (int) $this->pid);
+    $this->db->exec("DELETE FROM crawls WHERE id = " . (int) $this->cid);
+    $this->db->exec("DELETE FROM projects WHERE id = " . (int) $this->pid);
+    $this->db->prepare("DELETE FROM users WHERE id = :id")->execute([':id' => $this->uid]);
+});
+
+/** Seed a stored fragment whose query counts the project's categories. */
+function seedFragment(PDO $db, int $crawlId, int $projectId, string $key, int $stale, int $categoryDependent): void
+{
+    $sql    = 'SELECT count(*)::int AS c FROM crawl_categories WHERE project_id = :pid';
+    $params = json_encode([':pid' => $projectId]);
+    $payload = json_encode([['c' => $stale]]);
+    $db->prepare("
+        INSERT INTO crawl_report_cache (crawl_id, report_key, payload, query_sql, query_params, category_dependent, updated_at)
+        VALUES (:c, :k, :p, :sql, :prm, :cd, CURRENT_TIMESTAMP)
+        ON CONFLICT (crawl_id, report_key) DO UPDATE SET payload = :p2, query_sql = :sql2, query_params = :prm2, category_dependent = :cd2
+    ")->execute([
+        ':c' => $crawlId, ':k' => $key, ':p' => $payload, ':sql' => $sql, ':prm' => $params, ':cd' => $categoryDependent,
+        ':p2' => $payload, ':sql2' => $sql, ':prm2' => $params, ':cd2' => $categoryDependent,
+    ]);
+}
+
+function cachedCount(PDO $db, int $crawlId, string $key): ?int
+{
+    $raw = $db->query("SELECT payload FROM crawl_report_cache WHERE crawl_id = {$crawlId} AND report_key = " . $db->quote($key))->fetchColumn();
+    if ($raw === false || $raw === null) return null;
+    $rows = json_decode((string) $raw, true);
+    return isset($rows[0]['c']) ? (int) $rows[0]['c'] : null;
+}
+
+it('rewrites a category-dependent fragment so reports reflect the new categories', function () {
+    // Stored fragment says 0; reality (after a categorization change) is 2.
+    seedFragment($this->db, $this->cid, $this->pid, 'codes_by_category', 0, 1);
+    $this->db->exec("INSERT INTO crawl_categories (project_id, cat, color) VALUES ({$this->pid}, 'blog', '#111'), ({$this->pid}, 'product', '#222')");
+
+    expect(cachedCount($this->db, $this->cid, 'codes_by_category'))->toBe(0); // stale before
+
+    ReportPrecompute::recompute($this->cid, true);
+
+    // Recompute re-ran the stored query and rewrote the cached payload in place.
+    expect(cachedCount($this->db, $this->cid, 'codes_by_category'))->toBe(2);
+});
+
+it('leaves non-category-dependent fragments untouched when only refreshing category ones', function () {
+    seedFragment($this->db, $this->cid, $this->pid, 'static_fragment', 0, 0); // category_dependent = 0
+    $this->db->exec("INSERT INTO crawl_categories (project_id, cat, color) VALUES ({$this->pid}, 'blog', '#111')");
+
+    ReportPrecompute::recompute($this->cid, true); // onlyCategoryDependent = true
+
+    // cd=0 entries are not re-executed in the category-only pass → stays stale.
+    expect(cachedCount($this->db, $this->cid, 'static_fragment'))->toBe(0);
+
+    // A full recompute DOES refresh it.
+    ReportPrecompute::recompute($this->cid, false);
+    expect(cachedCount($this->db, $this->cid, 'static_fragment'))->toBe(1);
+});
+
+describe('API categorization triggers the report-precompute routine (regression guard)', function () {
+
+    it('ApiV1Controller::setCategorization recomputes this crawl and queues the project job', function () {
+        $src = file_get_contents(__DIR__ . '/../../app/Http/Controllers/ApiV1Controller.php');
+        // Isolate the setCategorization method body.
+        $start = strpos($src, 'public function setCategorization');
+        expect($start)->not->toBeFalse();
+        // Next public method after it marks the end of the body.
+        $end = strpos($src, 'public function crawlStatus', $start);
+        $body = substr($src, $start, $end - $start);
+
+        // Synchronous refresh of the current crawl's category-dependent fragments…
+        expect($body)->toContain('ReportPrecompute::recompute');
+        // …and the async project-wide refresh job, same as the UI save flow.
+        expect($body)->toContain('precompute-reports-project:');
+    });
+});

--- a/web/api/index.php
+++ b/web/api/index.php
@@ -177,11 +177,14 @@ try {
     $router->post('/bulk-generate/stop',           [BulkGenerateController::class, 'stop'],          ['auth' => true]);
 
     // =============================================================================
-    // API KEYS (session + admin) — managed from the Settings page
+    // API KEYS (session-authenticated) — managed from the Settings page by ANY
+    // logged-in user. Every operation is scoped to the caller (ApiKeyController
+    // uses $this->userId), so a user can only ever list/create/revoke their OWN
+    // keys. A key acts strictly within its owner's role/permissions on /api/v1.
     // =============================================================================
-    $router->get(   '/keys',      [ApiKeyController::class, 'index'],  ['auth' => true, 'admin' => true]);
-    $router->post(  '/keys',      [ApiKeyController::class, 'create'], ['auth' => true, 'admin' => true]);
-    $router->delete('/keys/{id}', [ApiKeyController::class, 'revoke'], ['auth' => true, 'admin' => true]);
+    $router->get(   '/keys',      [ApiKeyController::class, 'index'],  ['auth' => true]);
+    $router->post(  '/keys',      [ApiKeyController::class, 'create'], ['auth' => true]);
+    $router->delete('/keys/{id}', [ApiKeyController::class, 'revoke'], ['auth' => true]);
 
     // =============================================================================
     // PUBLIC API v1 — Bearer token auth (acts as the key's owner)

--- a/web/components/top-header.php
+++ b/web/components/top-header.php
@@ -216,6 +216,12 @@ $userInitials = getUserInitials($currentUserEmail);
                     <span class="material-symbols-outlined">settings</span>
                     <?= __('header.settings') ?>
                 </a>
+                <?php else: ?>
+                <!-- Non-admins get self-service access to their own API keys & MCP setup. -->
+                <a href="<?= $basePath ?>pages/settings.php?tab=api" class="user-dropdown-item">
+                    <span class="material-symbols-outlined">vpn_key</span>
+                    <?= __('header.api_mcp') ?>
+                </a>
                 <?php endif; ?>
                 <div class="user-dropdown-divider"></div>
                 <div style="display: flex; gap: 0.5rem; padding: 0.5rem 1rem;">

--- a/web/lang/de.json
+++ b/web/lang/de.json
@@ -739,6 +739,7 @@
   "header.project": "Projekt",
   "header.projects": "Projekte",
   "header.settings": "Einstellungen",
+  "header.api_mcp": "API- & MCP-Schlüssel",
   "header.system_monitor": "Systemüberwachung",
   "header.user_role": "Benutzer",
   "headings.card_analyzed": "Analysierte Seiten",

--- a/web/lang/en.json
+++ b/web/lang/en.json
@@ -740,6 +740,7 @@
   "header.project": "Project",
   "header.projects": "Projects",
   "header.settings": "Settings",
+  "header.api_mcp": "API & MCP keys",
   "header.system_monitor": "System Monitor",
   "header.user_role": "User",
   "headings.card_analyzed": "Pages analyzed",

--- a/web/lang/es.json
+++ b/web/lang/es.json
@@ -739,6 +739,7 @@
   "header.project": "Proyecto",
   "header.projects": "Proyectos",
   "header.settings": "Ajustes",
+  "header.api_mcp": "Claves API y MCP",
   "header.system_monitor": "Monitor del sistema",
   "header.user_role": "Usuario",
   "headings.card_analyzed": "Páginas analizadas",

--- a/web/lang/fr.json
+++ b/web/lang/fr.json
@@ -740,6 +740,7 @@
   "header.project": "Projet",
   "header.projects": "Projets",
   "header.settings": "Paramètres",
+  "header.api_mcp": "Clés API & MCP",
   "header.system_monitor": "System Monitor",
   "header.user_role": "Utilisateur",
   "headings.card_analyzed": "Pages analysées",

--- a/web/lang/it.json
+++ b/web/lang/it.json
@@ -739,6 +739,7 @@
   "header.project": "Progetto",
   "header.projects": "Progetti",
   "header.settings": "Impostazioni",
+  "header.api_mcp": "Chiavi API e MCP",
   "header.system_monitor": "Monitor di sistema",
   "header.user_role": "Utente",
   "headings.card_analyzed": "Pagine analizzate",

--- a/web/lang/pt.json
+++ b/web/lang/pt.json
@@ -739,6 +739,7 @@
   "header.project": "Projeto",
   "header.projects": "Projetos",
   "header.settings": "Configurações",
+  "header.api_mcp": "Chaves API e MCP",
   "header.system_monitor": "Monitor do Sistema",
   "header.user_role": "Utilizador",
   "headings.card_analyzed": "Páginas analisadas",

--- a/web/pages/settings.php
+++ b/web/pages/settings.php
@@ -14,11 +14,19 @@
  */
 
 require_once(__DIR__ . '/init.php');
-$auth->requireAdmin(false);
+// API & MCP key management is open to EVERY authenticated user: each user only
+// ever sees and manages their OWN keys, and any key acts strictly within its
+// owner's role/permissions. The AI provider, budget and team-management
+// sections stay admin-only and are rendered conditionally on $isAdmin below.
+$auth->requireLoginOrRedirect();
+$isAdmin = $auth->isAdmin();
 
 use App\Settings\AppSettings;
 use App\AI\BudgetService;
 
+// Everything below feeds the admin-only AI / budget / team sections. Skip it
+// entirely for non-admins so other users' data is never computed or exposed.
+if ($isAdmin) {
 $hasEncryption  = AppSettings::hasEncryptionKey();
 $apiKey         = AppSettings::get('ai.openrouter.api_key');
 $hasStoredKey   = $apiKey !== null && $apiKey !== '';
@@ -61,6 +69,7 @@ try {
     ");
     $teamMembers = $_tm->fetchAll(\PDO::FETCH_ASSOC) ?: [];
 } catch (\Throwable $e) { $teamMembers = []; }
+} // end if ($isAdmin)
 ?>
 <!DOCTYPE html>
 <html lang="<?= I18n::getInstance()->getLang() ?>">
@@ -707,7 +716,7 @@ try {
             </div>
         </div>
 
-        <?php if (!$hasEncryption): ?>
+        <?php if ($isAdmin && !$hasEncryption): ?>
         <div class="settings-warning">
             <?= __('settings.encryption_missing') ?>
             <code>SCOUTER_ENCRYPTION_KEY</code>
@@ -715,17 +724,20 @@ try {
         <?php endif; ?>
 
         <nav class="settings-tabs-nav" id="settingsTabsNav">
+            <?php if ($isAdmin): ?>
             <button type="button" class="settings-tab-btn active" data-tab="ai">
                 <span class="material-symbols-outlined">smart_toy</span> <?= __('settings.tab_ai') ?>
             </button>
             <button type="button" class="settings-tab-btn" data-tab="team">
                 <span class="material-symbols-outlined">group</span> <?= __('settings.tab_team') ?>
             </button>
-            <button type="button" class="settings-tab-btn" data-tab="api">
+            <?php endif; ?>
+            <button type="button" class="settings-tab-btn<?= $isAdmin ? '' : ' active' ?>" data-tab="api">
                 <span class="material-symbols-outlined">vpn_key</span> <?= __('settings.tab_api') ?>
             </button>
         </nav>
 
+        <?php if ($isAdmin): ?>
         <section class="settings-tab active" data-tab="ai">
 
         <!-- ================== AI Provider (OpenRouter) ================== -->
@@ -908,7 +920,9 @@ try {
             </button>
         </div>
         </section><!-- /tab ai -->
+        <?php endif; ?>
 
+        <?php if ($isAdmin): ?>
         <section class="settings-tab" data-tab="team">
         <!-- ============ AI BUDGET ============ -->
         <div class="settings-card" style="grid-column: 1 / -1;">
@@ -1017,8 +1031,9 @@ try {
             </button>
         </div>
         </section><!-- /tab team -->
+        <?php endif; ?>
 
-        <section class="settings-tab" data-tab="api">
+        <section class="settings-tab<?= $isAdmin ? '' : ' active' ?>" data-tab="api">
         <!-- ============ API & ACCESS KEYS ============ -->
         <div class="settings-card" style="grid-column: 1 / -1;">
             <h2><span class="material-symbols-outlined">key</span> <?= __('settings.api_title') ?></h2>
@@ -1252,7 +1267,8 @@ try {
         </section><!-- /tab api -->
     </div><!-- /.container -->
 
-    <!-- User add/edit modal (Team & Budgets tab) -->
+    <!-- User add/edit modal (Team & Budgets tab) — admin-only -->
+    <?php if ($isAdmin): ?>
     <div id="userModal" style="display:none; position:fixed; inset:0; z-index:1000; background:rgba(15,23,42,0.5); align-items:center; justify-content:center;">
         <div style="background:#fff; border-radius:14px; width:95vw; max-width:460px; padding:1.5rem;">
             <h3 id="userModalTitle" style="margin:0 0 1.2rem; font-size:1.1rem;"></h3>
@@ -1275,6 +1291,7 @@ try {
             </div>
         </div>
     </div>
+    <?php endif; ?>
 
     <script src="../assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>
@@ -2119,6 +2136,7 @@ try {
     })();
     </script>
 
+    <?php if ($isAdmin): /* AI provider + Dr. Brief prompt editor — admin-only */ ?>
     <script>
     (function () {
         const apiKeyInput   = document.getElementById('api-key');
@@ -2717,6 +2735,7 @@ try {
         })();
     })();
     </script>
+    <?php endif; ?>
 
     <script>
     // Single sticky Save per tab (spec §4). Each tab with a footer tracks its


### PR DESCRIPTION
## Summary

Two related changes that make the MCP server and public API fully usable by **every** authenticated user — not just admins — while keeping the existing authorization model completely intact, and fixing a stale-report bug on the API categorization path.

### 1. Open MCP & API + key/MCP settings to all roles
Previously, only admins could mint API keys or reach the Settings page, which made the MCP server and public API effectively admin-only even though `/api/v1` and the OAuth flow never had an admin gate.

- **API keys** (`web/api/index.php`): `/api/keys` (list/create/revoke) is no longer admin-gated. Every operation was already scoped to `$this->userId`, so each user only ever sees and manages their **own** keys.
- **Settings page** (`web/pages/settings.php`): opened to all logged-in users but **role-filtered**. Non-admins see **only** the "API & Access" tab (personal API keys + MCP server setup + interactive API explorer). The AI provider, AI budget and Team/user-management sections — plus their data, the user modal and their JS — render only for admins. The API tab is the active default for non-admins.
- **Header menu** (`web/components/top-header.php`): non-admins get an "API & MCP keys" entry (new `header.api_mcp` i18n key in all 6 locales) linking straight to `settings.php?tab=api`.

#### Why it's safe (no way to escape the permission system)
- A key always acts **as its owner**: the router resolves the Bearer token to the owner's `user_id` + role, so every downstream check runs unchanged.
- `/api/v1` already enforces, per endpoint: project visibility by role (admin = all, user = owned + shared, viewer = shared only), `requireProjectAccess` for reads, `requireProjectManagement` for categorization/schedules/stop/start, and `canCreate()` for crawl creation. Viewers stay strictly read-only; shared users cannot delete or re-categorize. Cross-crawl SQL (`@id`) stays within the same accessible project.
- OAuth (Claude connector) already required only a logged-in session (no admin check); the issued token preserves the user's role — no privilege escalation.
- Genuinely administrative routes (`/users`, `/settings`, `/settings/budget`) remain admin-only.

### 2. Fix report precache on API/MCP categorization
Saving a categorization through the public API / MCP (`ApiV1Controller::setCategorization`) persisted and applied the new rules but **never refreshed the precomputed, category-dependent report fragments** (`crawl_report_cache`: category distribution, Sankey flow, external links by category…). As a result, reports kept showing the **old** categories after a save from Claude/MCP, while the UI save flow refreshed them.

The API path now mirrors the UI routine (`CategorizationController::save`):
- synchronously recompute the current crawl's category-dependent fragments (`ReportPrecompute::recompute($cid, true)`) so the reports the caller looks at right after are fresh;
- queue an async project-wide `precompute-reports-project:<id>` job for the other crawls, created **after** the existing batch-categorize job so that, by the time it runs, every crawl's per-crawl YAML snapshot has been refreshed (the ClickHouse live `category` reads that snapshot) — otherwise the others would be recomputed against stale categories.

The API response now also reports the precompute state. Both steps are best-effort (failures logged, never break the save).

## Tests
- `tests/Unit/ApiKeyAccessTest.php` — static guard: `/keys` is auth-only (not admin), `/users` & `/settings` stay admin-only, every `/v1` route is token-guarded and never admin-gated.
- `ApiKeyServiceTest` — non-admin (user & viewer) can mint keys whose verified context keeps the owner's role unchanged.
- `OAuthServerTest` — a viewer can complete the code→token exchange and the issued key stays `role=viewer` (read-only, no escalation).
- `tests/Unit/ReportPrecomputeTest.php` — recompute rewrites a stored category-dependent fragment in place; non-category fragments untouched in a category-only pass (and refreshed by a full recompute); plus a regression guard that `setCategorization` invokes the precompute routine and queues the project job.

Full Unit suite green: **394 passed** (validated against a real Postgres).

## i18n
All 6 locales at full key parity (2144 keys each); `header.api_mcp` present everywhere; every `__()` key used in the touched pages exists.