### PR TITLE
fix: watchdog stops killing healthy crawls + crawl disguised as a real browser

### DIFF
--- a/crawler-go/cmd/scouter-crawler/main.go
+++ b/crawler-go/cmd/scouter-crawler/main.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 	"time"
 
+	"scouter-crawler/internal/analysis"
 	"scouter-crawler/internal/backfill"
 	"scouter-crawler/internal/config"
 	"scouter-crawler/internal/crawl"
@@ -319,6 +320,10 @@ func runJob(ctx context.Context, pool *db.Pool, ch *db.CH, mgr *jobs.Manager, j 
 		_ = mgr.UpdateStatus(ctx, j.ID, "failed", j.ProjectDir)
 		return
 	}
+
+	// robots.txt and sitemap fetches must identify with the SAME configured UA as
+	// the page crawler — set the package-wide UA before any of them runs.
+	analysis.SetUserAgent(cfg.UserAgent)
 
 	cdb := db.NewCrawlDB(pool, rec.ID)
 	if err := cdb.CreatePartitions(ctx); err != nil {

--- a/crawler-go/internal/analysis/headers.go
+++ b/crawler-go/internal/analysis/headers.go
@@ -1,0 +1,122 @@
+package analysis
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// headers.go centralises the request headers the crawler sends so that, over the
+// uTLS Chrome TLS fingerprint, the HTTP layer also looks like a real Chrome
+// navigation instead of a bare two-header bot request (the tell that gets a crawl
+// 403'd on day one by anti-bot stacks like DataDome).
+//
+// Hard rule: the configured crawl User-Agent is used VERBATIM on every request —
+// page fetch, robots.txt, sitemap. We never substitute another UA. The Client
+// Hints we add are DERIVED from that UA so they stay consistent with it.
+
+// fallbackUserAgent is the honest Scouter identity, used only if the worker never
+// called SetUserAgent (it always does before a crawl). It is never an
+// impersonation: it matches the config package's defaultUserAgent.
+const fallbackUserAgent = "Scouter/0.7 (Crawler developed by Lokoe SASU; +https://lokoe.fr/scouter-crawler)"
+
+// DefaultAcceptLanguage is sent when the crawl doesn't override Accept-Language
+// via custom headers. Realistic for the FR-first audience; overridable per crawl.
+const DefaultAcceptLanguage = "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7"
+
+var (
+	uaMu     sync.RWMutex
+	configUA = fallbackUserAgent
+)
+
+// SetUserAgent records the crawl's configured UA so the package-internal fetchers
+// (robots.txt, sitemap) send the exact same UA as the page crawler. Called once by
+// the worker at startup from the resolved crawl config.
+func SetUserAgent(ua string) {
+	if strings.TrimSpace(ua) == "" {
+		return
+	}
+	uaMu.Lock()
+	configUA = ua
+	uaMu.Unlock()
+}
+
+// UserAgent returns the configured crawl UA (or the honest fallback).
+func UserAgent() string {
+	uaMu.RLock()
+	defer uaMu.RUnlock()
+	return configUA
+}
+
+var chromeMajorRe = regexp.MustCompile(`(?i)(?:Chrome|Chromium|CriOS|Edg)/(\d+)`)
+
+// ApplyBrowserHeaders sets, on req, the header set a real Chrome top-level
+// navigation sends, using ua VERBATIM as the User-Agent. Client-Hint headers
+// (sec-ch-ua*) are only added for Chromium-family UAs — Firefox/Safari don't send
+// them, so adding them on a non-Chromium UA would itself be a fingerprint tell.
+// Caller-supplied custom headers should be applied AFTER this (they may tune
+// anything), but the UA must be re-asserted last so the configured UA always wins.
+func ApplyBrowserHeaders(req *http.Request, ua string) {
+	if strings.TrimSpace(ua) == "" {
+		ua = UserAgent()
+	}
+	h := req.Header
+	h.Set("User-Agent", ua)
+	h.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+	h.Set("Accept-Language", DefaultAcceptLanguage)
+	// Only encodings we can actually decode (see decompressBody): gzip/deflate/br.
+	h.Set("Accept-Encoding", "gzip, deflate, br")
+	h.Set("Upgrade-Insecure-Requests", "1")
+	// Fetch metadata for a user-initiated top-level navigation.
+	h.Set("Sec-Fetch-Dest", "document")
+	h.Set("Sec-Fetch-Mode", "navigate")
+	h.Set("Sec-Fetch-Site", "none")
+	h.Set("Sec-Fetch-User", "?1")
+
+	if major := chromeMajor(ua); major != "" {
+		h.Set("sec-ch-ua", secCHUA(major))
+		h.Set("sec-ch-ua-mobile", chMobile(ua))
+		h.Set("sec-ch-ua-platform", chPlatform(ua))
+	}
+}
+
+// chromeMajor returns the Chromium-family major version in ua, or "".
+func chromeMajor(ua string) string {
+	if m := chromeMajorRe.FindStringSubmatch(ua); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// secCHUA builds the low-entropy sec-ch-ua brand list for a Chrome major version,
+// mirroring the GREASE-padded format Chrome emits.
+func secCHUA(major string) string {
+	return `"Chromium";v="` + major + `", "Google Chrome";v="` + major + `", "Not_A Brand";v="99"`
+}
+
+func chMobile(ua string) string {
+	if strings.Contains(ua, "Mobile") || strings.Contains(ua, "Android") || strings.Contains(ua, "iPhone") {
+		return "?1"
+	}
+	return "?0"
+}
+
+func chPlatform(ua string) string {
+	switch {
+	case strings.Contains(ua, "Windows"):
+		return `"Windows"`
+	case strings.Contains(ua, "Android"):
+		return `"Android"`
+	case strings.Contains(ua, "CrOS"):
+		return `"Chrome OS"`
+	case strings.Contains(ua, "Mac OS X") || strings.Contains(ua, "Macintosh"):
+		return `"macOS"`
+	case strings.Contains(ua, "iPhone") || strings.Contains(ua, "iPad"):
+		return `"iOS"`
+	case strings.Contains(ua, "Linux") || strings.Contains(ua, "X11"):
+		return `"Linux"`
+	default:
+		return `"Windows"`
+	}
+}

--- a/crawler-go/internal/analysis/headers_test.go
+++ b/crawler-go/internal/analysis/headers_test.go
@@ -1,0 +1,54 @@
+package analysis
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestApplyBrowserHeaders_ChromeUA(t *testing.T) {
+	const ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	ApplyBrowserHeaders(req, ua)
+
+	if got := req.Header.Get("User-Agent"); got != ua {
+		t.Fatalf("User-Agent not verbatim: got %q", got)
+	}
+	for _, h := range []string{"Accept", "Accept-Language", "Accept-Encoding", "Upgrade-Insecure-Requests",
+		"Sec-Fetch-Dest", "Sec-Fetch-Mode", "Sec-Fetch-Site", "Sec-Fetch-User"} {
+		if req.Header.Get(h) == "" {
+			t.Errorf("missing browser header %q", h)
+		}
+	}
+	if got := req.Header.Get("sec-ch-ua"); got == "" || !contains(got, `v="124"`) {
+		t.Errorf("sec-ch-ua not derived from UA major: %q", got)
+	}
+	if got := req.Header.Get("sec-ch-ua-platform"); got != `"Windows"` {
+		t.Errorf("sec-ch-ua-platform = %q, want \"Windows\"", got)
+	}
+	if got := req.Header.Get("sec-ch-ua-mobile"); got != "?0" {
+		t.Errorf("sec-ch-ua-mobile = %q, want ?0", got)
+	}
+}
+
+func TestApplyBrowserHeaders_NonChromeUA_NoClientHints(t *testing.T) {
+	// A Firefox UA must NOT get sec-ch-ua headers (Firefox doesn't send them).
+	const ua = "Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"
+	req, _ := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	ApplyBrowserHeaders(req, ua)
+
+	if got := req.Header.Get("User-Agent"); got != ua {
+		t.Fatalf("User-Agent not verbatim: got %q", got)
+	}
+	if got := req.Header.Get("sec-ch-ua"); got != "" {
+		t.Errorf("sec-ch-ua should be absent for Firefox UA, got %q", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/crawler-go/internal/analysis/robots.go
+++ b/crawler-go/internal/analysis/robots.go
@@ -21,8 +21,9 @@ type Robots struct {
 
 var defaultRobots = NewRobots()
 
-// NewRobots builds a Robots cache with a Googlebot-style fetcher (120s timeout,
-// SSRF-validated, http(s) only — like RobotsTxt::get_file).
+// NewRobots builds a Robots cache. The fetcher uses the configured crawl UA
+// (120s timeout, SSRF-validated, http(s) only — like RobotsTxt::get_file); only
+// the directive interpretation treats us as Googlebot.
 func NewRobots() *Robots {
 	return &Robots{
 		cache:  make(map[string]string),
@@ -167,7 +168,10 @@ func (r *Robots) fetch(url string) string {
 	if err != nil {
 		return ""
 	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+	// robots.txt is fetched with OUR configured UA like every other request — we
+	// only INTERPRET the directives as Googlebot (see the agents map in Allowed),
+	// which is a separate concern from how we identify on the wire.
+	ApplyBrowserHeaders(req, UserAgent())
 	resp, err := r.client.Do(req)
 	if err != nil {
 		return ""

--- a/crawler-go/internal/analysis/sitemap.go
+++ b/crawler-go/internal/analysis/sitemap.go
@@ -199,7 +199,8 @@ func (p *SitemapParser) fetch(url string) []byte {
 		p.result.Errors = append(p.result.Errors, url+" ("+err.Error()+")")
 		return nil
 	}
-	req.Header.Set("User-Agent", "Scouter/SitemapFetcher (+https://lokoe.fr/scouter)")
+	// Same configured UA as the page crawler — no separate sitemap identity.
+	ApplyBrowserHeaders(req, UserAgent())
 	resp, err := p.client.Do(req)
 	if err != nil {
 		p.result.Errors = append(p.result.Errors, url+" ("+err.Error()+")")

--- a/crawler-go/internal/crawl/engine.go
+++ b/crawler-go/internal/crawl/engine.go
@@ -266,11 +266,15 @@ func (e *Engine) fetchOne(ctx context.Context, rawURL string) fetchResult {
 		res.err = err
 		return res
 	}
-	req.Header.Set("User-Agent", e.cfg.UserAgent)
-	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	// Full Chrome-like navigation headers (consistent with the uTLS Chrome TLS
+	// fingerprint), so a non-JS fetch doesn't read as a bare two-header bot.
+	analysis.ApplyBrowserHeaders(req, e.cfg.UserAgent)
 	for k, v := range e.cfg.CustomHeaders {
 		req.Header.Set(k, v)
 	}
+	// The configured UA is authoritative everywhere: custom headers may tune the
+	// rest, but never the User-Agent.
+	req.Header.Set("User-Agent", e.cfg.UserAgent)
 	if e.cfg.HTTPAuth.Enabled {
 		req.SetBasicAuth(e.cfg.HTTPAuth.Username, e.cfg.HTTPAuth.Password)
 	}

--- a/renderer/main.go
+++ b/renderer/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -181,7 +182,13 @@ func initBrowser() error {
 	// Lancer Chrome avec les options optimisées pour VPS/Docker
 	u := launcher.New().
 		Bin(chromePath).
-		Headless(true).
+		// New headless = the real Chrome rendering path, far less detectable than
+		// the legacy headless shell (whose UA/behaviour give the bot away).
+		Set("headless", "new").
+		// Remove the navigator.webdriver / "controlled by automated software" tell.
+		Set("disable-blink-features", "AutomationControlled").
+		// Keep the browser locale consistent with the Accept-Language we send.
+		Set("lang", "fr-FR").
 		Set("disable-gpu").
 		Set("no-sandbox").
 		Set("disable-setuid-sandbox").
@@ -261,6 +268,90 @@ func stableTimeout() time.Duration {
 	return 5 * time.Second
 }
 
+// stealthJS masks the most common headless/automation tells in every document
+// the page loads. Injected once per page via AddScriptToEvaluateOnNewDocument.
+const stealthJS = `
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+window.chrome = window.chrome || { runtime: {} };
+Object.defineProperty(navigator, 'languages', { get: () => ['fr-FR', 'fr', 'en-US', 'en'] });
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+try {
+  const q = window.navigator.permissions && window.navigator.permissions.query;
+  if (q) {
+    window.navigator.permissions.query = (p) =>
+      p && p.name === 'notifications'
+        ? Promise.resolve({ state: Notification.permission })
+        : q(p);
+  }
+} catch (e) {}
+`
+
+func applyStealth(page *rod.Page) {
+	_, _ = proto.PageAddScriptToEvaluateOnNewDocument{Source: stealthJS}.Call(page)
+}
+
+var chromeMajorRe = regexp.MustCompile(`(?i)(?:Chrome|Chromium|CriOS|Edg)/(\d+)`)
+
+// uaOverride builds the CDP user-agent override for the configured UA, deriving
+// Client-Hint metadata (brands/platform/mobile) from it so navigator.userAgent
+// and sec-ch-ua* stay consistent with the UA we present.
+func uaOverride(ua string) *proto.NetworkSetUserAgentOverride {
+	o := &proto.NetworkSetUserAgentOverride{
+		UserAgent:      ua,
+		AcceptLanguage: "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7",
+		Platform:       navigatorPlatform(ua),
+	}
+	if m := chromeMajorRe.FindStringSubmatch(ua); m != nil {
+		major := m[1]
+		o.UserAgentMetadata = &proto.EmulationUserAgentMetadata{
+			Brands: []*proto.EmulationUserAgentBrandVersion{
+				{Brand: "Chromium", Version: major},
+				{Brand: "Google Chrome", Version: major},
+				{Brand: "Not_A Brand", Version: "99"},
+			},
+			FullVersion:  major + ".0.0.0",
+			Platform:     uaPlatformName(ua),
+			Architecture: "x86",
+			Mobile:       strings.Contains(ua, "Mobile") || strings.Contains(ua, "Android"),
+		}
+	}
+	return o
+}
+
+// navigatorPlatform returns the navigator.platform value matching the UA's OS.
+func navigatorPlatform(ua string) string {
+	switch {
+	case strings.Contains(ua, "Windows"):
+		return "Win32"
+	case strings.Contains(ua, "Mac OS X") || strings.Contains(ua, "Macintosh"):
+		return "MacIntel"
+	case strings.Contains(ua, "Android"):
+		return "Linux armv8l"
+	case strings.Contains(ua, "Linux") || strings.Contains(ua, "X11"):
+		return "Linux x86_64"
+	default:
+		return "Win32"
+	}
+}
+
+// uaPlatformName returns the Client-Hint platform name matching the UA's OS.
+func uaPlatformName(ua string) string {
+	switch {
+	case strings.Contains(ua, "Windows"):
+		return "Windows"
+	case strings.Contains(ua, "Android"):
+		return "Android"
+	case strings.Contains(ua, "CrOS"):
+		return "Chrome OS"
+	case strings.Contains(ua, "Mac OS X") || strings.Contains(ua, "Macintosh"):
+		return "macOS"
+	case strings.Contains(ua, "Linux") || strings.Contains(ua, "X11"):
+		return "Linux"
+	default:
+		return "Windows"
+	}
+}
+
 func getPage() (*rod.Page, error) {
 	markActivity() // keeps the pool reaper from closing tabs mid-crawl
 
@@ -281,6 +372,10 @@ func getPage() (*rod.Page, error) {
 			<-semaphore // rendre le slot avant de remonter l'erreur
 			return nil, err
 		}
+		// Inject the anti-detection patches once, at page creation: the script runs
+		// on every new document for this page's lifetime, so reused pooled pages stay
+		// patched without re-injecting (which would stack listeners/leak).
+		_ = rod.Try(func() { applyStealth(page) })
 		return page, nil
 	}
 }
@@ -313,14 +408,25 @@ func renderURL(urlStr string, headers map[string]string) RenderResponse {
 	}
 	defer releasePage(page)
 
-	// Configurer les headers (Rod prend des paires key, value). Protégé : un
-	// MustSetExtraHeaders qui panique ne doit pas court-circuiter releasePage.
-	if len(headers) > 0 {
-		args := make([]string, 0, len(headers)*2)
-		for k, v := range headers {
-			args = append(args, k, v)
+	// Le User-Agent est appliqué via CDP setUserAgentOverride (PAS un simple extra
+	// header) : sinon navigator.userAgent et les Client Hints (sec-ch-ua*) restent
+	// ceux du Chrome headless réel et trahissent le bot malgré le header. L'UA
+	// fournie par la config est utilisée telle quelle, et les Client Hints en sont
+	// dérivés pour rester cohérents. Les autres headers passent en extra headers.
+	var ua string
+	extra := make([]string, 0, len(headers)*2)
+	for k, v := range headers {
+		if strings.EqualFold(k, "User-Agent") {
+			ua = v
+			continue
 		}
-		_ = rod.Try(func() { page.MustSetExtraHeaders(args...) })
+		extra = append(extra, k, v)
+	}
+	if ua != "" {
+		_ = rod.Try(func() { page.MustSetUserAgent(uaOverride(ua)) })
+	}
+	if len(extra) > 0 {
+		_ = rod.Try(func() { page.MustSetExtraHeaders(extra...) })
 	}
 
 	// Variables pour capturer le code HTTP et le TTFB

--- a/scripts/watchdog.php
+++ b/scripts/watchdog.php
@@ -7,7 +7,17 @@ use App\Job\JobManager;
 
 // Configuration
 $stateFile = __DIR__ . '/../logs/watchdog_state.json'; // Fichier pour stocker l'état précédent
-$inactivityThreshold = '1 hour'; // Seuil d'inactivité avant de tuer
+
+// Un job n'est tué QUE si sa progression (crawls.crawled) est restée strictement
+// identique pendant au moins $inactivitySeconds de temps réel écoulé. On ne se
+// fie plus à « deux passages consécutifs du watchdog avec le même compteur » :
+// avec un cron horaire ça tuait des crawls sains dont le compteur plafonnait
+// brièvement ou qui venaient d'être (re)lancés. On mémorise donc l'instant du
+// dernier changement de progression et on ne tue qu'après une vraie inactivité.
+$inactivitySeconds = 2 * 3600; // 2 h sans le moindre changement de progression
+// Période de grâce après le démarrage du job : on ne juge jamais un job qui vient
+// de démarrer (le temps qu'il amorce le crawl et fasse grimper le compteur).
+$graceSeconds = 15 * 60; // 15 min
 $dryRun = false;
 
 // Récupération des options CLI
@@ -53,6 +63,8 @@ try {
         exit(0);
     }
 
+    $now = time();
+
     foreach ($runningJobs as $job) {
         $jobId = $job->id;
         // Use crawl progress (crawls.crawled) as source of truth, fallback to jobs.progress
@@ -61,61 +73,84 @@ try {
         echo "🔍 Checking Job #{$jobId} ({$job->project_dir})...\n";
         echo "   Current Progress: $currentProgress URLs (job: {$job->progress}, crawl: {$job->crawl_progress})\n";
 
-        // Si on a déjà vu ce job la dernière fois
+        // --- Période de grâce : on ne juge pas un job fraîchement (re)démarré. ---
+        $startedTs = !empty($job->started_at) ? strtotime($job->started_at) : false;
+        if ($startedTs !== false && ($now - $startedTs) < $graceSeconds) {
+            $ageMin = round(($now - $startedTs) / 60, 1);
+            echo "   🐣 Grace period ({$ageMin} min < " . ($graceSeconds / 60) . " min since start). Skipping.\n";
+            // On (ré)amorce la baseline avec l'instant courant comme dernier changement,
+            // pour ne pas hériter d'un last_change périmé une fois la grâce terminée.
+            $newState[$jobId] = [
+                'progress'    => $currentProgress,
+                'timestamp'   => $now,
+                'last_change' => $now,
+                'project_dir' => $job->project_dir,
+            ];
+            continue;
+        }
+
+        // --- Détection de blocage fondée sur la DURÉE RÉELLE d'inactivité. ---
+        // last_change = dernier instant où la progression a effectivement bougé.
         if (isset($previousState[$jobId])) {
-            $lastCheckTime = $previousState[$jobId]['timestamp'];
-            $lastProgress = $previousState[$jobId]['progress'];
-            
-            // Calculer le temps écoulé depuis le dernier check
-            $timeDiff = time() - $lastCheckTime;
-            $hoursElapsed = round($timeDiff / 3600, 1);
-            
-            echo "   Last check was $hoursElapsed hours ago (Progress was: $lastProgress)\n";
+            $lastProgress = (int)($previousState[$jobId]['progress'] ?? 0);
+            // Rétro-compat : anciens états sans 'last_change' -> on retombe sur 'timestamp'.
+            $lastChange = (int)($previousState[$jobId]['last_change'] ?? $previousState[$jobId]['timestamp'] ?? $now);
 
-            // VÉRIFICATION : Est-ce que ça a bougé ?
-            if ($currentProgress === $lastProgress) {
-                // Ça n'a pas bougé !
-                echo "   ⚠️ STUCK DETECTED: Progress hasn't changed ($currentProgress) since last check.\n";
-                
-                if (!$dryRun) {
-                    echo "   🔪 Killing stuck job...\n";
-
-                    $jobManager->updateJobStatus($job->id, 'failed');
-                    $jobManager->setJobError($job->id, "WATCHDOG: Job killed because stuck at $currentProgress URLs for > 1 check cycle");
-                    $jobManager->addLog($job->id, "💀 WATCHDOG: Job killed. No progress detected since last check.", 'error');
-
-                    // Mettre à jour les stats du crawl pour que l'UI affiche les vrais chiffres
-                    $crawlId = $job->crawl_id ?? null;
-                    if ($crawlId) {
-                        $db->prepare("
-                            UPDATE crawls SET
-                                urls = (SELECT COUNT(*) FROM pages WHERE crawl_id = :cid1),
-                                crawled = (SELECT COUNT(*) FROM pages WHERE crawl_id = :cid2 AND crawled = true),
-                                status = 'failed',
-                                finished_at = CURRENT_TIMESTAMP,
-                                in_progress = 0
-                            WHERE id = :cid3
-                        ")->execute([':cid1' => $crawlId, ':cid2' => $crawlId, ':cid3' => $crawlId]);
-                        echo "   📊 Crawl #$crawlId stats updated.\n";
-                    }
-
-                    echo "   ✅ Job killed.\n";
-                    continue; // Ne pas l'ajouter au newState
-                } else {
-                    echo "   [DRY RUN] Would kill this job.\n";
-                }
-            } else {
+            if ($currentProgress !== $lastProgress) {
+                // La progression a bougé (dans un sens ou l'autre) -> job vivant, on réarme.
                 echo "   ✅ Moving! ($lastProgress -> $currentProgress). Job is healthy.\n";
+                $lastChange = $now;
+            } else {
+                // Compteur figé : on regarde DEPUIS COMBIEN DE TEMPS, pas juste « un cycle ».
+                $stuckFor = $now - $lastChange;
+                $stuckMin = round($stuckFor / 60, 1);
+                echo "   ⏳ Progress unchanged ($currentProgress) for {$stuckMin} min (threshold " . round($inactivitySeconds / 60) . " min).\n";
+
+                if ($stuckFor >= $inactivitySeconds) {
+                    echo "   ⚠️ STUCK DETECTED: no progress for {$stuckMin} min.\n";
+
+                    if (!$dryRun) {
+                        echo "   🔪 Killing stuck job...\n";
+
+                        $jobManager->updateJobStatus($job->id, 'failed');
+                        $jobManager->setJobError($job->id, "WATCHDOG: Job killed because stuck at $currentProgress URLs for {$stuckMin} min");
+                        $jobManager->addLog($job->id, "💀 WATCHDOG: Job killed. No progress for {$stuckMin} min.", 'error');
+
+                        // Mettre à jour les stats du crawl pour que l'UI affiche les vrais chiffres
+                        $crawlId = $job->crawl_id ?? null;
+                        if ($crawlId) {
+                            $db->prepare("
+                                UPDATE crawls SET
+                                    urls = (SELECT COUNT(*) FROM pages WHERE crawl_id = :cid1),
+                                    crawled = (SELECT COUNT(*) FROM pages WHERE crawl_id = :cid2 AND crawled = true),
+                                    status = 'failed',
+                                    finished_at = CURRENT_TIMESTAMP,
+                                    in_progress = 0
+                                WHERE id = :cid3
+                            ")->execute([':cid1' => $crawlId, ':cid2' => $crawlId, ':cid3' => $crawlId]);
+                            echo "   📊 Crawl #$crawlId stats updated.\n";
+                        }
+
+                        echo "   ✅ Job killed.\n";
+                        continue; // Ne pas l'ajouter au newState
+                    } else {
+                        echo "   [DRY RUN] Would kill this job.\n";
+                    }
+                } else {
+                    echo "   🙂 Within threshold — sparing the job (could be a slow depth, retries, or idle worker).\n";
+                }
             }
         } else {
             echo "   🆕 First time seeing this job (or watchdog restart). Recording baseline.\n";
+            $lastChange = $now;
         }
 
         // Sauvegarder l'état actuel pour la prochaine fois
         $newState[$jobId] = [
-            'progress' => $currentProgress,
-            'timestamp' => time(),
-            'project_dir' => $job->project_dir
+            'progress'    => $currentProgress,
+            'timestamp'   => $now,
+            'last_change' => $lastChange,
+            'project_dir' => $job->project_dir,
         ];
     }
 


### PR DESCRIPTION
Bundles two related crawl-reliability fixes.

## 1. Watchdog — no more false positives (`scripts/watchdog.php`)

**Problem**: a perfectly healthy crawl was finalized as `failed` ("crawl marked failed (watchdog)"), cut off mid-walk, with post-processing aborted. The Go worker was only reacting to the `status='failed'` set by the watchdog.

**Root cause**: the watchdog killed a job as soon as `crawls.crawled` was **identical between two cron passes** (hourly), with no real notion of elapsed time — the `'1 hour'` threshold was decorative, never applied. A counter that briefly plateaus, a momentarily idle worker, or a freshly (re)started job = killed, with no error at all.

**Fix**:
- Track `last_change` (the last time progress actually moved) and only kill after a **continuous inactivity of ≥ 2 h** of real elapsed time, instead of "two equal samples". Any change in the counter re-arms the timer.
- **15 min grace period** after `started_at`: a freshly started job is never judged.
- Backward-compatible with old state files (falls back to `timestamp`).

## 2. Crawl disguised as a real browser (`crawler-go` + `renderer`)

**Problem**: 403 on the very first URL on protected sites (DataDome, etc.). The TLS fingerprint was properly disguised (uTLS Chrome), but the HTTP layer only sent `User-Agent` + `Accept` — a bot-looking header set inconsistent with the advertised Chrome UA. In JS mode the UA was only overridden via an extra header (`navigator.userAgent` stayed `HeadlessChrome`) with no anti-automation protection.

**UA everywhere, verbatim**: the configured UA is used as-is on **every** request (page, robots.txt, sitemap) — no more hardcoded UA. For robots.txt, the Googlebot identity is kept only for **interpreting the directives**, not for the request itself.

**HTTP mode (no JS)** — `analysis.ApplyBrowserHeaders`:
- full real-Chrome navigation header set: `Accept`, `Accept-Language`, `Accept-Encoding: gzip, deflate, br`, `Upgrade-Insecure-Requests`, `Sec-Fetch-*`;
- `sec-ch-ua*` Client Hints **derived from the UA**, only for Chromium UAs (otherwise it would itself be a tell);
- the configured UA is re-asserted after custom headers → always authoritative.

**JS mode (rod/Chrome renderer)**:
- new headless (`--headless=new`);
- `--disable-blink-features=AutomationControlled` + stealth script (`navigator.webdriver`, `languages`, `plugins`, `permissions`);
- UA applied via CDP `setUserAgentOverride` + `userAgentMetadata` → `navigator.userAgent` AND Client Hints aligned with the configured UA.

Tests: `go build ./...`, `go vet ./...` pass; `internal/analysis` + `internal/crawl` tests green (incl. a new `headers_test.go`).

## ⚠️ Notes
- **`renderer/scouter-renderer` binary** (a committed build artifact) is **not included** — rebuild it via the usual pipeline/Docker so JS mode picks up these changes.
- Residual limitations not covered here: **header ordering** and **HTTP/2 fingerprint** (Go ≠ Chrome; uTLS only fixes TLS), and the **datacenter IP** that DataDome often blocks outright (would require residential proxies/IPs, independent of the code).
