### PR TITLE
fix(sitemap): restore the sitemap report on ClickHouse

### DIFF
--- a/app/Database/ChPdo.php
+++ b/app/Database/ChPdo.php
@@ -219,7 +219,12 @@ class ChPdo
             $joins .= " LEFT JOIN (SELECT crawl_id AS _gcid, id AS _gid, generation "
                 . "FROM {$this->db}.page_generation WHERE crawl_id IN ({$in}) LIMIT 1 BY (crawl_id, id)) g ON g._gcid = p.crawl_id AND g._gid = p.id";
         }
-        $cols[] = "toUInt8(1) AS in_crawl";
+        // in_crawl: a page reached by the crawl vs. a sitemap-only placeholder. The
+        // post-processing stores sitemap-only rows (in the sitemap but not crawled)
+        // with depth = -1 — the only rows with a negative depth — so in_crawl is the
+        // inverse of that sentinel. Hardcoding 1 here (before this fix) made every
+        // sitemap-only URL look crawled, collapsing the sitemap report's buckets.
+        $cols[] = "if(p.depth < 0, toUInt8(0), toUInt8(1)) AS in_crawl";
         return "(SELECT " . implode(', ', $cols)
             . " FROM (SELECT * FROM {$this->db}.pages WHERE crawl_id IN ({$in}) LIMIT 1 BY (crawl_id, id)) p"
             . $joins . ")";

--- a/app/Export/ExportService.php
+++ b/app/Export/ExportService.php
@@ -443,8 +443,8 @@ class ExportService
         // crawl_id predicate for that alias; without `cs.crawl_id`/`ct.crawl_id`
         // the join hash table is built over EVERY crawl's pages (millions of rows)
         // → MEMORY_LIMIT_EXCEEDED on big sites. Scoping each side keeps it small
-        // (~1 GiB, ~1s vs OOM). (in_crawl is synthesised as a constant 1 in CH, so
-        // there's no point filtering on it here.) No ORDER BY: sorting tens of
+        // (~1 GiB, ~1s vs OOM). (No in_crawl filter: sitemap-only placeholders have
+        // no links, so they never reach this src/target join anyway.) No ORDER BY: sorting tens of
         // millions of joined rows in CH would blow the memory limit anyway.
         $sql = "SELECT {$select} FROM links l "
             . "JOIN pages cs ON l.src = cs.id AND cs.crawl_id = {$cid} "

--- a/crawler-go/cmd/scouter-crawler/main.go
+++ b/crawler-go/cmd/scouter-crawler/main.go
@@ -433,7 +433,7 @@ func runJob(ctx context.Context, pool *db.Pool, ch *db.CH, mgr *jobs.Manager, j 
 	// Post-processing in ClickHouse (PageRank/inlinks/semantic/duplicate/redirect)
 	// → derived tables. Runs in addition to PG during the dual-write transition.
 	if ch != nil {
-		chpp := postprocess.NewCHRunner(ch, rec.ID, postprocess.RespectNofollowFromConfig(rec.Config), logf)
+		chpp := postprocess.NewCHRunner(ch, pool, rec.ID, postprocess.RespectNofollowFromConfig(rec.Config), logf)
 		ppFailures = append(ppFailures, chpp.Run(ctx)...)
 		// In full-CH mode the PG post-processor is skipped, so write the
 		// duplicate/redirect scorecard stats back to crawls.* from ClickHouse.

--- a/crawler-go/internal/backfill/backfill.go
+++ b/crawler-go/internal/backfill/backfill.go
@@ -455,7 +455,7 @@ func (b *Backfiller) migrate(ctx context.Context, crawlID int, withHTML bool) er
 	// Post-processing in ClickHouse (page_metrics, duplicate, redirect).
 	var cfg []byte
 	_ = b.pool.QueryRow(ctx, "SELECT config FROM crawls WHERE id=$1", crawlID).Scan(&cfg)
-	postprocess.NewCHRunner(b.ch, crawlID, postprocess.RespectNofollowFromConfig(cfg), b.logf).Run(ctx)
+	postprocess.NewCHRunner(b.ch, b.pool, crawlID, postprocess.RespectNofollowFromConfig(cfg), b.logf).Run(ctx)
 	b.SyncStats(ctx, crawlID) // write back duplicate/redirect scorecard stats
 
 	// Completeness check before flipping the read store.

--- a/crawler-go/internal/postprocess/clickhouse.go
+++ b/crawler-go/internal/postprocess/clickhouse.go
@@ -21,9 +21,14 @@ import (
 // over Memory tables instead of PG temp-table UPDATEs.
 type CHRunner struct {
 	ch              *db.CH
+	pool            *db.Pool // PostgreSQL — source of truth for the sitemap dimension (may be nil)
 	crawlID         int
 	respectNofollow bool
 	logf            func(string, ...any)
+
+	// sitemapTable is the Memory table of in_sitemap page ids built by loadSitemap;
+	// buildMetrics joins it to flag page_metrics.in_sitemap. Empty = no sitemap.
+	sitemapTable string
 }
 
 // RespectNofollowFromConfig reads advanced.respect_nofollow (default true, like
@@ -33,14 +38,17 @@ func RespectNofollowFromConfig(raw []byte) bool {
 }
 
 // NewCHRunner returns a CH post-processor, or nil if ch is nil (CH disabled).
-func NewCHRunner(ch *db.CH, crawlID int, respectNofollow bool, logf func(string, ...any)) *CHRunner {
+// pool is the PostgreSQL pool: the PG post-processing's sitemapAnalysis is the
+// source of truth for the sitemap dimension (in_sitemap flags + sitemap-only rows),
+// which loadSitemap copies into ClickHouse. May be nil (sitemap step is then a no-op).
+func NewCHRunner(ch *db.CH, pool *db.Pool, crawlID int, respectNofollow bool, logf func(string, ...any)) *CHRunner {
 	if ch == nil {
 		return nil
 	}
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
-	return &CHRunner{ch: ch, crawlID: crawlID, respectNofollow: respectNofollow, logf: logf}
+	return &CHRunner{ch: ch, pool: pool, crawlID: crawlID, respectNofollow: respectNofollow, logf: logf}
 }
 
 func (r *CHRunner) t(name string) string { return r.ch.DB() + "." + name }
@@ -52,6 +60,13 @@ func (r *CHRunner) cid() string          { return strconv.Itoa(r.crawlID) }
 // pages read so the derived tables are built from clean, one-row-per-page data.
 func (r *CHRunner) pd() string {
 	return "(SELECT * FROM " + r.t("pages") + " WHERE crawl_id = " + r.cid() + " LIMIT 1 BY id)"
+}
+
+// pdCrawl is pd() restricted to pages actually reached by the crawl (depth >= 0).
+// Sitemap-only placeholder rows are stored with depth = -1, so this excludes them
+// from PageRank (which mirrors the PG pagerank's `WHERE in_crawl = TRUE`).
+func (r *CHRunner) pdCrawl() string {
+	return "(SELECT * FROM " + r.t("pages") + " WHERE crawl_id = " + r.cid() + " AND depth >= 0 LIMIT 1 BY id)"
 }
 
 // Run executes the CH post-processing steps, isolating failures per step.
@@ -67,6 +82,9 @@ func (r *CHRunner) Run(ctx context.Context) []string {
 		name string
 		fn   func(context.Context) error
 	}{
+		// First: pull the sitemap dimension from PG into CH so buildMetrics can flag
+		// in_sitemap and the sitemap-only rows are countable.
+		{"ch-sitemap", r.loadSitemap},
 		{"ch-pagerank+metrics", r.buildMetrics},
 		{"ch-duplicate", r.duplicateAnalysis},
 		{"ch-redirect", r.redirectChainAnalysis},
@@ -96,6 +114,9 @@ func (r *CHRunner) buildMetrics(ctx context.Context) error {
 	defer func() {
 		_ = r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+r.t("pr_cur_"+r.cid()))
 		_ = r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+r.t("pr_next_"+r.cid()))
+		if r.sitemapTable != "" {
+			_ = r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+r.sitemapTable)
+		}
 	}()
 
 	cid := r.cid()
@@ -114,15 +135,221 @@ func (r *CHRunner) buildMetrics(ctx context.Context) error {
 	inlinksSub := `(SELECT target AS tid, count() AS inlinks FROM ` + r.t("links") +
 		` WHERE crawl_id = ` + cid + ` GROUP BY target)`
 
+	// in_sitemap: 1 when the page id is in the sitemap set loaded from PG, else 0.
+	// (Hardcoded 0 until #38's CH migration was fixed — which silently zeroed every
+	// crawl's sitemap report.) When there is no sitemap, sitemapTable is empty → 0.
+	inSitemap := "0"
+	if r.sitemapTable != "" {
+		inSitemap = "if(p.id IN (SELECT id FROM " + r.sitemapTable + "), 1, 0)"
+	}
+
 	sql := `INSERT INTO ` + r.t("page_metrics") +
 		` (crawl_id, id, inlinks, pri, title_status, h1_status, metadesc_status, in_sitemap)
-		SELECT ` + cid + `, p.id, il.inlinks, pr.pr, st.title_status, st.h1_status, st.metadesc_status, 0
+		SELECT ` + cid + `, p.id, il.inlinks, pr.pr, st.title_status, st.h1_status, st.metadesc_status, ` + inSitemap + `
 		FROM ` + r.pd() + ` p
 		LEFT JOIN ` + inlinksSub + ` il ON il.tid = p.id
 		LEFT JOIN ` + r.t("pr_cur_"+cid) + ` pr ON pr.id = p.id
 		LEFT JOIN ` + statusSub + ` st ON st.id = p.id
 		WHERE p.crawl_id = ` + cid
 	return r.ch.Exec(ctx, sql)
+}
+
+// loadSitemap brings the sitemap dimension into ClickHouse. The PG post-processing
+// (sitemapAnalysis) is the source of truth: it parses the sitemap, flags the
+// crawled pages that appear in it (pages.in_sitemap), and inserts sitemap-only
+// placeholder rows (in_crawl = FALSE, depth = -1) for URLs that are in the sitemap
+// but were not reached by the crawl. None of that ever reached ClickHouse — the CH
+// page_metrics.in_sitemap was hardcoded to 0 and the placeholders were never copied
+// — so the sitemap report read all-zeros once a crawl was on ClickHouse. This step:
+//
+//  1. loads the in_sitemap id set into a Memory table that buildMetrics joins, and
+//  2. copies the sitemap-only rows into CH `pages` (depth -1 preserved), so the
+//     read shim derives in_crawl = FALSE and the "sitemap only" / "total sitemap"
+//     counts are complete.
+//
+// No-op when there is no PG pool or the crawl has no sitemap data (leaves in_sitemap
+// at 0). Runs before buildMetrics so the placeholders exist when page_metrics is
+// built — PageRank uses pdCrawl() (depth >= 0) so the placeholders never skew it.
+func (r *CHRunner) loadSitemap(ctx context.Context) error {
+	if r.pool == nil {
+		return nil
+	}
+	var n int
+	if err := r.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM pages WHERE crawl_id=$1 AND in_sitemap=TRUE", r.crawlID).Scan(&n); err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil // no sitemap configured, or nothing matched — nothing to mark
+	}
+
+	// 1) in_sitemap id set → Memory table joined by buildMetrics.
+	tbl := r.t("sitemap_ids_" + r.cid())
+	if err := r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
+		return err
+	}
+	if err := r.ch.Exec(ctx, "CREATE TABLE "+tbl+" (id FixedString(8)) ENGINE = Memory"); err != nil {
+		return err
+	}
+	idRows, err := r.pool.Query(ctx, "SELECT id FROM pages WHERE crawl_id=$1 AND in_sitemap=TRUE", r.crawlID)
+	if err != nil {
+		return err
+	}
+	batch := make([]any, 0, 2000)
+	flushIDs := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		err := r.ch.InsertJSONEachRow(ctx, tbl, batch)
+		batch = batch[:0]
+		return err
+	}
+	for idRows.Next() {
+		var id string
+		if err := idRows.Scan(&id); err != nil {
+			idRows.Close()
+			return err
+		}
+		batch = append(batch, map[string]any{"id": strings.TrimSpace(id)})
+		if len(batch) >= 2000 {
+			if err := flushIDs(); err != nil {
+				idRows.Close()
+				return err
+			}
+		}
+	}
+	idRows.Close()
+	if err := idRows.Err(); err != nil {
+		return err
+	}
+	if err := flushIDs(); err != nil {
+		return err
+	}
+	r.sitemapTable = tbl
+
+	// 2) sitemap-only rows (in the sitemap, not in the crawl graph) → CH pages.
+	return r.copySitemapOnlyPages(ctx)
+}
+
+// copySitemapOnlyPages copies the PG sitemap-only rows (in_crawl = FALSE) into CH
+// `pages` so they are countable by the report. depth is forced to -1 (the
+// placeholder sentinel) so the read shim classifies them as in_crawl = FALSE.
+//
+// Ids already present in CH are skipped: an in-scope sitemap URL fetched during the
+// PG sitemap pass was written to CH by the crawl store (with its real depth), and a
+// second row for the same id would corrupt duplicate detection (its simhash counted
+// twice) and the in_crawl classification. Those keep their fetched row (counted as
+// crawl ∩ sitemap); only the never-fetched URLs become depth -1 placeholders.
+func (r *CHRunner) copySitemapOnlyPages(ctx context.Context) error {
+	cid := r.cid()
+
+	// Candidate ids, then drop those already in CH so we never write a 2nd row/id.
+	candRows, err := r.pool.Query(ctx, "SELECT id FROM pages WHERE crawl_id=$1 AND in_crawl=FALSE", r.crawlID)
+	if err != nil {
+		return err
+	}
+	var candidates []string
+	for candRows.Next() {
+		var id string
+		if err := candRows.Scan(&id); err != nil {
+			candRows.Close()
+			return err
+		}
+		candidates = append(candidates, strings.TrimSpace(id))
+	}
+	candRows.Close()
+	if err := candRows.Err(); err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	existing := map[string]bool{}
+	for _, c := range chunk(candidates, 5000) {
+		tsv, err := r.ch.QueryTSV(ctx, "SELECT id FROM "+r.t("pages")+" WHERE crawl_id="+cid+" AND id IN ("+quoteList(c)+")")
+		if err != nil {
+			return err
+		}
+		for _, row := range tsv {
+			if len(row) > 0 {
+				existing[strings.TrimSpace(row[0])] = true
+			}
+		}
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, domain, url, code, response_time, outlinks, content_type, redirect_to,
+		       crawled, compliant, noindex, nofollow, canonical, canonical_value, external, blocked,
+		       title, h1, metadesc, simhash, word_count
+		FROM pages WHERE crawl_id=$1 AND in_crawl=FALSE`, r.crawlID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	batch := make([]any, 0, 2000)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		err := r.ch.InsertJSONEachRow(ctx, r.t("pages"), batch)
+		batch = batch[:0]
+		return err
+	}
+	for rows.Next() {
+		var (
+			id                                                                        string
+			domain, url, contentType, redirectTo, canonicalValue, title, h1, metadesc *string
+			outlinks, wordCount                                                       int
+			code                                                                      *int
+			responseTime                                                              *float64
+			crawled, compliant, noindex, nofollow, canonical, external, blocked       bool
+			simhash                                                                   *int64
+		)
+		if err := rows.Scan(&id, &domain, &url, &code, &responseTime, &outlinks, &contentType, &redirectTo,
+			&crawled, &compliant, &noindex, &nofollow, &canonical, &canonicalValue, &external, &blocked,
+			&title, &h1, &metadesc, &simhash, &wordCount); err != nil {
+			return err
+		}
+		id = strings.TrimSpace(id)
+		if existing[id] {
+			continue // already in CH (fetched in-scope) — keep that row
+		}
+		codeV := 0
+		if code != nil {
+			codeV = *code
+		}
+		rtV := 0.0
+		if responseTime != nil {
+			rtV = *responseTime
+		}
+		batch = append(batch, map[string]any{
+			"crawl_id": r.crawlID, "id": id, "domain": chStr(domain), "url": chStr(url),
+			"depth": -1, "code": codeV, "response_time": rtV, "outlinks": outlinks,
+			"content_type": chStr(contentType), "redirect_to": chStr(redirectTo), "crawled": b2iCH(crawled),
+			"compliant": b2iCH(compliant), "noindex": b2iCH(noindex), "nofollow": b2iCH(nofollow),
+			"canonical": b2iCH(canonical), "canonical_value": chStr(canonicalValue), "external": b2iCH(external),
+			"blocked": b2iCH(blocked), "title": chStr(title), "h1": chStr(h1), "metadesc": chStr(metadesc),
+			"extracts": map[string]string{}, "simhash": simhash, "is_html": 0, "h1_multiple": 0,
+			"headings_missing": 0, "schemas": []string{}, "word_count": wordCount,
+		})
+		if len(batch) >= 2000 {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return flush()
+}
+
+// chStr derefs a nullable PG string column to "" (CH has no NULLs in those cols).
+func chStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // optimizeFinal merges this crawl's partitions so subsequent report reads work
@@ -155,7 +382,7 @@ func (r *CHRunner) computePageRank(ctx context.Context) error {
 		}
 	}
 
-	pagesCountStr, err := r.ch.QueryScalar(ctx, "SELECT count() FROM "+r.pd())
+	pagesCountStr, err := r.ch.QueryScalar(ctx, "SELECT count() FROM "+r.pdCrawl())
 	if err != nil {
 		return err
 	}
@@ -171,14 +398,14 @@ func (r *CHRunner) computePageRank(ctx context.Context) error {
 
 	if !hasLinks {
 		// No graph: pri stays 0 (matches PG, which skips the update entirely).
-		return r.ch.Exec(ctx, "INSERT INTO "+prCur+" SELECT id, 0, 0 FROM "+r.pd())
+		return r.ch.Exec(ctx, "INSERT INTO "+prCur+" SELECT id, 0, 0 FROM "+r.pdCrawl())
 	}
 
 	initPR := 1.0 / float64(pagesCount)
 	bonus := (1 - damping) / float64(pagesCount)
 	if err := r.ch.Exec(ctx, `INSERT INTO `+prCur+`
 		SELECT p.id, `+f(initPR)+`, ol.c
-		FROM `+r.pd()+` p
+		FROM `+r.pdCrawl()+` p
 		LEFT JOIN `+outlinksSub+` ol ON ol.sid = p.id`); err != nil {
 		return err
 	}

--- a/crawler-go/internal/postprocess/clickhouse.go
+++ b/crawler-go/internal/postprocess/clickhouse.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"scouter-crawler/internal/analysis"
 	"scouter-crawler/internal/db"
 )
 
@@ -154,36 +155,61 @@ func (r *CHRunner) buildMetrics(ctx context.Context) error {
 	return r.ch.Exec(ctx, sql)
 }
 
-// loadSitemap brings the sitemap dimension into ClickHouse. The PG post-processing
-// (sitemapAnalysis) is the source of truth: it parses the sitemap, flags the
-// crawled pages that appear in it (pages.in_sitemap), and inserts sitemap-only
-// placeholder rows (in_crawl = FALSE, depth = -1) for URLs that are in the sitemap
-// but were not reached by the crawl. None of that ever reached ClickHouse — the CH
-// page_metrics.in_sitemap was hardcoded to 0 and the placeholders were never copied
-// — so the sitemap report read all-zeros once a crawl was on ClickHouse. This step:
+// loadSitemap brings the sitemap dimension into ClickHouse, natively — it does NOT
+// rely on the PG post-processing's sitemapAnalysis, because in full-ClickHouse mode
+// (CLICKHOUSE_DROP_PG=1) that step is skipped entirely. It parses the configured
+// sitemap(s) itself, then:
 //
-//  1. loads the in_sitemap id set into a Memory table that buildMetrics joins, and
-//  2. copies the sitemap-only rows into CH `pages` (depth -1 preserved), so the
-//     read shim derives in_crawl = FALSE and the "sitemap only" / "total sitemap"
-//     counts are complete.
+//  1. loads every sitemap page id into a Memory table that buildMetrics joins to
+//     flag page_metrics.in_sitemap (crawled pages that appear in the sitemap), and
+//  2. inserts the sitemap-only URLs (in the sitemap but not reached by the crawl)
+//     into CH `pages` as depth = -1 placeholders, so the read shim classifies them
+//     in_crawl = FALSE and the "sitemap only" / "total sitemap" counts are complete.
 //
-// No-op when there is no PG pool or the crawl has no sitemap data (leaves in_sitemap
-// at 0). Runs before buildMetrics so the placeholders exist when page_metrics is
-// built — PageRank uses pdCrawl() (depth >= 0) so the placeholders never skew it.
+// No-op when there is no PG pool (config lives in PG `crawls`, which survives the
+// data-partition drop) or the crawl has no sitemap configured. Runs before
+// buildMetrics so the placeholders exist when page_metrics is built — PageRank uses
+// pdCrawl() (depth >= 0) so the placeholders never skew it.
 func (r *CHRunner) loadSitemap(ctx context.Context) error {
 	if r.pool == nil {
 		return nil
 	}
-	var n int
-	if err := r.pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM pages WHERE crawl_id=$1 AND in_sitemap=TRUE", r.crawlID).Scan(&n); err != nil {
+	// Config + domain come from the crawls row (present even in DROP_PG mode — only
+	// the crawl-DATA partitions are dropped, the metadata row stays).
+	var raw []byte
+	var domain string
+	if err := r.pool.QueryRow(ctx, "SELECT config, domain FROM crawls WHERE id=$1", r.crawlID).Scan(&raw, &domain); err != nil {
 		return err
 	}
-	if n == 0 {
-		return nil // no sitemap configured, or nothing matched — nothing to mark
+	var sitemapURLs []string
+	for _, u := range advancedStrings(raw, "sitemap_urls") {
+		if t := strings.TrimSpace(u); t != "" {
+			sitemapURLs = append(sitemapURLs, t)
+		}
+	}
+	if len(sitemapURLs) == 0 {
+		return nil // no sitemap configured
 	}
 
-	// 1) in_sitemap id set → Memory table joined by buildMetrics.
+	result := analysis.NewSitemapParser().Parse(sitemapURLs)
+	if len(result.URLs) == 0 {
+		if len(result.Errors) > 0 {
+			r.logf("ch-sitemap: parsed 0 URLs (%d fetch/parse error(s), first: %s)", len(result.Errors), result.Errors[0])
+		}
+		return nil
+	}
+	r.logf("ch-sitemap: %d URLs parsed from %d sitemap(s)", len(result.URLs), len(result.SitemapsVisited))
+
+	idToURL := make(map[string]string, len(result.URLs))
+	for _, u := range result.URLs {
+		idToURL[analysis.PageID(u)] = u
+	}
+	allIDs := make([]string, 0, len(idToURL))
+	for id := range idToURL {
+		allIDs = append(allIDs, id)
+	}
+
+	// 1) sitemap_ids Memory table (ALL ids) — buildMetrics joins it for in_sitemap.
 	tbl := r.t("sitemap_ids_" + r.cid())
 	if err := r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
 		return err
@@ -191,82 +217,27 @@ func (r *CHRunner) loadSitemap(ctx context.Context) error {
 	if err := r.ch.Exec(ctx, "CREATE TABLE "+tbl+" (id FixedString(8)) ENGINE = Memory"); err != nil {
 		return err
 	}
-	idRows, err := r.pool.Query(ctx, "SELECT id FROM pages WHERE crawl_id=$1 AND in_sitemap=TRUE", r.crawlID)
-	if err != nil {
-		return err
-	}
-	batch := make([]any, 0, 2000)
-	flushIDs := func() error {
-		if len(batch) == 0 {
-			return nil
-		}
-		err := r.ch.InsertJSONEachRow(ctx, tbl, batch)
-		batch = batch[:0]
-		return err
-	}
-	for idRows.Next() {
-		var id string
-		if err := idRows.Scan(&id); err != nil {
-			idRows.Close()
-			return err
-		}
-		batch = append(batch, map[string]any{"id": strings.TrimSpace(id)})
-		if len(batch) >= 2000 {
-			if err := flushIDs(); err != nil {
-				idRows.Close()
+	idBatch := make([]any, 0, 2000)
+	for _, id := range allIDs {
+		idBatch = append(idBatch, map[string]any{"id": id})
+		if len(idBatch) >= 2000 {
+			if err := r.ch.InsertJSONEachRow(ctx, tbl, idBatch); err != nil {
 				return err
 			}
+			idBatch = idBatch[:0]
 		}
 	}
-	idRows.Close()
-	if err := idRows.Err(); err != nil {
-		return err
-	}
-	if err := flushIDs(); err != nil {
+	if err := r.ch.InsertJSONEachRow(ctx, tbl, idBatch); err != nil {
 		return err
 	}
 	r.sitemapTable = tbl
 
-	// 2) sitemap-only rows (in the sitemap, not in the crawl graph) → CH pages.
-	return r.copySitemapOnlyPages(ctx)
-}
-
-// copySitemapOnlyPages copies the PG sitemap-only rows (in_crawl = FALSE) into CH
-// `pages` so they are countable by the report. depth is forced to -1 (the
-// placeholder sentinel) so the read shim classifies them as in_crawl = FALSE.
-//
-// Ids already present in CH are skipped: an in-scope sitemap URL fetched during the
-// PG sitemap pass was written to CH by the crawl store (with its real depth), and a
-// second row for the same id would corrupt duplicate detection (its simhash counted
-// twice) and the in_crawl classification. Those keep their fetched row (counted as
-// crawl ∩ sitemap); only the never-fetched URLs become depth -1 placeholders.
-func (r *CHRunner) copySitemapOnlyPages(ctx context.Context) error {
-	cid := r.cid()
-
-	// Candidate ids, then drop those already in CH so we never write a 2nd row/id.
-	candRows, err := r.pool.Query(ctx, "SELECT id FROM pages WHERE crawl_id=$1 AND in_crawl=FALSE", r.crawlID)
-	if err != nil {
-		return err
-	}
-	var candidates []string
-	for candRows.Next() {
-		var id string
-		if err := candRows.Scan(&id); err != nil {
-			candRows.Close()
-			return err
-		}
-		candidates = append(candidates, strings.TrimSpace(id))
-	}
-	candRows.Close()
-	if err := candRows.Err(); err != nil {
-		return err
-	}
-	if len(candidates) == 0 {
-		return nil
-	}
+	// 2) which sitemap ids already exist as CH pages (crawled)? the rest become
+	//    depth -1 placeholders. Skipping the existing ones means we never write a
+	//    second row per id (which would corrupt duplicate detection / in_crawl).
 	existing := map[string]bool{}
-	for _, c := range chunk(candidates, 5000) {
-		tsv, err := r.ch.QueryTSV(ctx, "SELECT id FROM "+r.t("pages")+" WHERE crawl_id="+cid+" AND id IN ("+quoteList(c)+")")
+	for _, c := range chunk(allIDs, 5000) {
+		tsv, err := r.ch.QueryTSV(ctx, "SELECT id FROM "+r.t("pages")+" WHERE crawl_id="+r.cid()+" AND id IN ("+quoteList(c)+")")
 		if err != nil {
 			return err
 		}
@@ -277,15 +248,10 @@ func (r *CHRunner) copySitemapOnlyPages(ctx context.Context) error {
 		}
 	}
 
-	rows, err := r.pool.Query(ctx, `
-		SELECT id, domain, url, code, response_time, outlinks, content_type, redirect_to,
-		       crawled, compliant, noindex, nofollow, canonical, canonical_value, external, blocked,
-		       title, h1, metadesc, simhash, word_count
-		FROM pages WHERE crawl_id=$1 AND in_crawl=FALSE`, r.crawlID)
-	if err != nil {
-		return err
+	allowed := generalStrings(raw, "domains")
+	if len(allowed) == 0 {
+		allowed = []string{domain}
 	}
-	defer rows.Close()
 	batch := make([]any, 0, 2000)
 	flush := func() error {
 		if len(batch) == 0 {
@@ -295,61 +261,35 @@ func (r *CHRunner) copySitemapOnlyPages(ctx context.Context) error {
 		batch = batch[:0]
 		return err
 	}
-	for rows.Next() {
-		var (
-			id                                                                        string
-			domain, url, contentType, redirectTo, canonicalValue, title, h1, metadesc *string
-			outlinks, wordCount                                                       int
-			code                                                                      *int
-			responseTime                                                              *float64
-			crawled, compliant, noindex, nofollow, canonical, external, blocked       bool
-			simhash                                                                   *int64
-		)
-		if err := rows.Scan(&id, &domain, &url, &code, &responseTime, &outlinks, &contentType, &redirectTo,
-			&crawled, &compliant, &noindex, &nofollow, &canonical, &canonicalValue, &external, &blocked,
-			&title, &h1, &metadesc, &simhash, &wordCount); err != nil {
-			return err
-		}
-		id = strings.TrimSpace(id)
+	placeholders := 0
+	for id, u := range idToURL {
 		if existing[id] {
-			continue // already in CH (fetched in-scope) — keep that row
+			continue // in the crawl already → marked in_sitemap by buildMetrics
 		}
-		codeV := 0
-		if code != nil {
-			codeV = *code
-		}
-		rtV := 0.0
-		if responseTime != nil {
-			rtV = *responseTime
+		external := 0
+		if !urlInScope(u, allowed) {
+			external = 1
 		}
 		batch = append(batch, map[string]any{
-			"crawl_id": r.crawlID, "id": id, "domain": chStr(domain), "url": chStr(url),
-			"depth": -1, "code": codeV, "response_time": rtV, "outlinks": outlinks,
-			"content_type": chStr(contentType), "redirect_to": chStr(redirectTo), "crawled": b2iCH(crawled),
-			"compliant": b2iCH(compliant), "noindex": b2iCH(noindex), "nofollow": b2iCH(nofollow),
-			"canonical": b2iCH(canonical), "canonical_value": chStr(canonicalValue), "external": b2iCH(external),
-			"blocked": b2iCH(blocked), "title": chStr(title), "h1": chStr(h1), "metadesc": chStr(metadesc),
-			"extracts": map[string]string{}, "simhash": simhash, "is_html": 0, "h1_multiple": 0,
-			"headings_missing": 0, "schemas": []string{}, "word_count": wordCount,
+			"crawl_id": r.crawlID, "id": id, "domain": smDomain(u), "url": truncate(u, 2083),
+			"depth": -1, "code": 0, "response_time": 0.0, "outlinks": 0, "content_type": "",
+			"redirect_to": "", "crawled": 0, "compliant": 0, "noindex": 0, "nofollow": 0,
+			"canonical": 0, "canonical_value": "", "external": external, "blocked": 0,
+			"title": "", "h1": "", "metadesc": "", "extracts": map[string]string{}, "simhash": nil,
+			"is_html": 0, "h1_multiple": 0, "headings_missing": 0, "schemas": []string{}, "word_count": 0,
 		})
+		placeholders++
 		if len(batch) >= 2000 {
 			if err := flush(); err != nil {
 				return err
 			}
 		}
 	}
-	if err := rows.Err(); err != nil {
+	if err := flush(); err != nil {
 		return err
 	}
-	return flush()
-}
-
-// chStr derefs a nullable PG string column to "" (CH has no NULLs in those cols).
-func chStr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
+	r.logf("ch-sitemap: %d in crawl, %d sitemap-only placeholder(s)", len(existing), placeholders)
+	return nil
 }
 
 // optimizeFinal merges this crawl's partitions so subsequent report reads work


### PR DESCRIPTION
## Problem

Since the ClickHouse migration (#38), the sitemap report read all-zeros once a crawl was on ClickHouse: "URLs dans le sitemap = 0", "Crawl & sitemap = 0", and every indexable page bucketed into "indexables absentes du sitemap". The sitemap feature was effectively dead on the CH read path.

## Root cause

The PG post-processing computed the sitemap dimension correctly, but **none of it ever reached ClickHouse**:

- `page_metrics.in_sitemap` was **hardcoded to `0`** for every page (`clickhouse.go`);
- sitemap-only rows (in the sitemap, not crawled) were **never written to CH**;
- the read shim (`ChPdo`) **hardcoded `in_crawl = 1`**, so a sitemap-only row could not be told apart from a crawled one.

On top of that, in **full-ClickHouse mode (`CLICKHOUSE_DROP_PG=1`)** the entire PG post-processing — including the sitemap analysis — is skipped, so there was no PG source to lean on at all.

## Fix

The ClickHouse post-processing now owns the sitemap dimension natively, independent of PostgreSQL:

- **New `ch-sitemap` step (`loadSitemap`)** parses the configured sitemap(s) itself (`analysis.SitemapParser`), loads every sitemap page id into a Memory table, and inserts the not-in-crawl URLs into CH `pages` as `depth = -1` placeholders (in-scope vs out-of-scope from the crawl's domains). Config + domain are read from the `crawls` row, which survives the data-partition drop. It skips ids already present in CH, so it never double-writes a page (which would corrupt duplicate detection / `in_crawl`).
- **`buildMetrics`** flags `page_metrics.in_sitemap` from that set; PageRank uses a `depth >= 0` source so the placeholders never skew it.
- **`ChPdo`** derives `in_crawl` from the `depth = -1` sentinel instead of a constant `1`.

Works in both modes: full-CH (no PG post-processing) and dual-write. No schema change (`page_metrics.in_sitemap` already existed). Backfill picks the new step up automatically (same `CHRunner`).