### PR TITLE
Harden dev debug scripts

### DIFF
--- a/scripts/create-demo-user.php
+++ b/scripts/create-demo-user.php
@@ -1,10 +1,23 @@
 <?php
 /**
- * Crée l'utilisateur demo/demo par défaut
- * Usage: php create-demo-user.php
+ * Crée l'utilisateur demo/demo par défaut.
+ *
+ * Disabled by default to avoid accidentally creating a known admin account.
+ * Usage: SCOUTER_ALLOW_DEMO_USER=true php scripts/create-demo-user.php
  */
 
-require("vendor/autoload.php");
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+$allowDemo = strtolower((string)getenv('SCOUTER_ALLOW_DEMO_USER'));
+if (!in_array($allowDemo, ['1', 'true', 'yes'], true)) {
+    fwrite(STDERR, "Refusing to create demo admin. Set SCOUTER_ALLOW_DEMO_USER=true to enable this dev-only script.\n");
+    exit(1);
+}
+
+require(__DIR__ . "/../vendor/autoload.php");
 
 use App\Database\UserRepository;
 

--- a/web/diagnostic.php
+++ b/web/diagnostic.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Script de diagnostic et d'auto-réparation pour Scouter
+ * Script de diagnostic et d'auto-réparation pour Scouter.
+ *
+ * CLI only. This file lives under web/ for historical reasons, but it must not
+ * expose instance details over HTTP.
  * 
  * Vérifie:
  * 1. La connexion base de données
@@ -10,7 +13,14 @@
  * 5. La configuration PHP
  */
 
-require_once __DIR__ . '/vendor/autoload.php';
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit;
+}
+
+$root = dirname(__DIR__);
+
+require_once $root . '/vendor/autoload.php';
 
 use App\Database\PostgresDatabase;
 
@@ -73,8 +83,8 @@ if (!empty($missingTables)) {
 // 4. Directory Permissions
 echo "\n4. Checking Directories...\n";
 $dirs = [
-    'logs' => __DIR__ . '/logs',
-    'web/assets' => __DIR__ . '/web/assets'
+    'logs' => $root . '/logs',
+    'web/assets' => $root . '/web/assets'
 ];
 
 foreach ($dirs as $name => $path) {


### PR DESCRIPTION
## Summary

This PR hardens two development/debug scripts:

- makes web/diagnostic.php CLI-only and returns 404 over HTTP
- fixes diagnostic autoload and directory checks from the repository root
- makes scripts/create-demo-user.php CLI-only
- disables demo admin creation by default unless SCOUTER_ALLOW_DEMO_USER=true is set
- fixes the demo-user script autoload path

## Why

The diagnostic script exposes instance details and should not be reachable over HTTP. The demo-user helper creates a known admin account and should require an explicit opt-in.

## Validation

- php -l web/diagnostic.php
- php -l scripts/create-demo-user.php
- host HTTP /diagnostic.php returned 404 during local validation
- in-container HTTP /diagnostic.php returned 404 during local validation
- CLI diagnostic still ran successfully
- create-demo-user.php refused by default and demo@scouter.local count remained 0
- full Pest suite passed during the combined local validation: 392 passed, 2 skipped, 941 assertions