### PR TITLE
Add jobs schema migration

### DIFF
--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -126,6 +126,35 @@ CREATE INDEX idx_crawls_project_id ON crawls(project_id);
 CREATE INDEX idx_crawls_domain ON crawls(domain);
 CREATE INDEX idx_crawls_status ON crawls(status);
 
+-- File de jobs asynchrones (crawls, exports, suppressions, batch jobs).
+-- Aussi créée en migration pour les volumes existants.
+CREATE TABLE jobs (
+    id SERIAL PRIMARY KEY,
+    project_dir TEXT NOT NULL,
+    project_name TEXT NOT NULL,
+    status VARCHAR(20) DEFAULT 'pending',
+    progress INTEGER DEFAULT 0,
+    pid INTEGER DEFAULT NULL,
+    command TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP DEFAULT NULL,
+    finished_at TIMESTAMP DEFAULT NULL,
+    error TEXT DEFAULT NULL
+);
+
+CREATE TABLE job_logs (
+    id SERIAL PRIMARY KEY,
+    job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+    message TEXT,
+    type VARCHAR(20) DEFAULT 'info',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_jobs_project_dir ON jobs(project_dir);
+CREATE INDEX idx_jobs_status ON jobs(status);
+CREATE INDEX idx_job_logs_job_id ON job_logs(job_id);
+CREATE INDEX idx_jobs_status_created ON jobs(status, created_at);
+
 -- Configuration de catégorisation par crawl (contenu YAML du cat.yml)
 CREATE TABLE categorization_config (
     id SERIAL PRIMARY KEY,
@@ -599,5 +628,6 @@ INSERT INTO migrations (name) VALUES
     ('2026-05-24-16-00-crawl-critical-errors'),
     ('2026-05-25-10-00-report-precompute-cache'),
     ('2026-05-25-12-00-report-cache-query-columns'),
-    ('2026-05-27-12-00-crawl-health-score')
+    ('2026-05-27-12-00-crawl-health-score'),
+    ('2026-05-28-09-00-jobs-table')
 ON CONFLICT (name) DO NOTHING;

--- a/migrations/2026-05-28-09-00-jobs-table.php
+++ b/migrations/2026-05-28-09-00-jobs-table.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Migration: create the async jobs tables at schema-migration time.
+ *
+ * JobManager also creates these tables lazily, but workers and the Go crawler can
+ * start before any request instantiates JobManager on a fresh install.
+ */
+$pdo = \App\Database\PostgresDatabase::getInstance()->getConnection();
+
+try {
+    $pdo->exec("
+        CREATE TABLE IF NOT EXISTS jobs (
+            id SERIAL PRIMARY KEY,
+            project_dir TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            status VARCHAR(20) DEFAULT 'pending',
+            progress INTEGER DEFAULT 0,
+            pid INTEGER DEFAULT NULL,
+            command TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            started_at TIMESTAMP DEFAULT NULL,
+            finished_at TIMESTAMP DEFAULT NULL,
+            error TEXT DEFAULT NULL
+        )
+    ");
+
+    $pdo->exec("
+        CREATE TABLE IF NOT EXISTS job_logs (
+            id SERIAL PRIMARY KEY,
+            job_id INTEGER NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+            message TEXT,
+            type VARCHAR(20) DEFAULT 'info',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ");
+
+    $pdo->exec("CREATE INDEX IF NOT EXISTS idx_jobs_project_dir ON jobs(project_dir)");
+    $pdo->exec("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)");
+    $pdo->exec("CREATE INDEX IF NOT EXISTS idx_job_logs_job_id ON job_logs(job_id)");
+    $pdo->exec("CREATE INDEX IF NOT EXISTS idx_jobs_status_created ON jobs(status, created_at)");
+
+    echo "(created jobs tables) ";
+    return true;
+} catch (\Exception $e) {
+    echo "Error: " . $e->getMessage();
+    return false;
+}


### PR DESCRIPTION
## Summary

This PR adds the missing asynchronous jobs schema to fresh PostgreSQL installs and existing databases:

- creates jobs and job_logs in docker/postgres/init.sql
- adds an idempotent migration for existing volumes
- records the migration name in the fresh-install migration baseline

## Why

Workers and crawler-related code can touch jobs/job_logs before the lazy JobManager table creation path has run. On a fresh install, that can leave the local stack with missing tables during startup.

## Validation

- php -l migrations/2026-05-28-09-00-jobs-table.php
- destructive fresh-volume validation run confirmed jobs and job_logs exist immediately after stack startup
- full Pest suite passed during the combined local validation: 392 passed, 2 skipped, 941 assertions