### PR TITLE
Add local install validation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,10 @@
 /logs/
 /crawls/
 /storage/
-composer.lock
 .env
 .claude
 .phpunit.cache/
+tests/validation/*.log
 # Composer binary — le build Docker utilise l'image composer:latest, pas ce phar
 composer.phar
 .env.autosize

--- a/tests/validation/local-dev-install-hardening.md
+++ b/tests/validation/local-dev-install-hardening.md
@@ -1,0 +1,69 @@
+# Local Dev Install and Hardening Validation
+
+Date: 2026-06-23T14:11:51+02:00
+
+Branch: `fix/local-dev-install`
+
+## Scope
+
+This validation covers the local development install fixes and hardening changes:
+
+- Rootless Podman / SELinux bind mount labels in `docker-compose.local.yml`.
+- Fresh install baseline schema for `jobs` and `job_logs`.
+- `composer.lock` based Docker build using `composer install`.
+- CLI-only `web/diagnostic.php`.
+- Opt-in-only `scripts/create-demo-user.php`.
+- Removal of privileged auto-install behavior from `start.sh`.
+
+## Commands and Results
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Composer manifest | `composer validate --strict` | Pass: `./composer.json is valid` |
+| Composer locked install plan | `composer install --dry-run --no-interaction --prefer-dist --optimize-autoloader` | Pass: lock file installable; 69 installs planned |
+| Composer advisories | `composer audit --locked` | Pass: no security vulnerability advisories found |
+| PHP lint, diagnostic | `php -l web/diagnostic.php` | Pass: no syntax errors |
+| PHP lint, demo user script | `php -l scripts/create-demo-user.php` | Pass: no syntax errors |
+| Shell syntax | `bash -n start.sh` | Pass |
+| Whitespace check | `git diff --check` | Pass |
+| Compose config | `docker compose -f docker-compose.local.yml config` | Pass |
+| PHP image build | `docker compose -f docker-compose.local.yml build scouter worker` | Pass: Composer installed from `composer.lock` |
+| Fresh stack reset | `tests/validation/run-local-dev-install-hardening.sh --fresh --yes` | Pass: Compose containers and volumes dropped, stack rebuilt from empty volumes |
+| Stack startup | `docker compose -f docker-compose.local.yml up -d --force-recreate --scale worker=4 --remove-orphans` | Pass |
+| HTTP app entrypoint | `curl -sS -I http://localhost:8080` | Pass: `HTTP/1.1 302 Found`, redirects to login |
+| Jobs schema | dynamic `compose_exec postgres psql -U scouter -d scouter -c '\dt job*'` | Pass: `jobs` and `job_logs` present on fresh volume |
+| Diagnostic host HTTP exposure | `curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/diagnostic.php` | Pass: `404` |
+| Diagnostic container HTTP exposure | dynamic `compose_exec scouter curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/diagnostic.php` | Pass: `404` |
+| Diagnostic CLI behavior | dynamic `compose_exec scouter php /app/web/diagnostic.php` | Pass: DB connection, key tables, and directories checked |
+| Demo user default behavior | dynamic `compose_exec scouter php /app/scripts/create-demo-user.php` | Pass: exits non-zero and refuses to create demo admin |
+| Demo user absence | dynamic `compose_exec postgres psql -U scouter -d scouter -tAc "SELECT count(*) FROM users WHERE email = 'demo@scouter.local';"` | Pass: `0` |
+| Pest suite | dynamic `compose_exec scouter ./vendor/bin/pest` | Pass: 392 passed, 2 skipped, 941 assertions |
+| Final stack status | `docker compose -f docker-compose.local.yml ps` | Pass: postgres, clickhouse, renderers, scouter, workers, mcp, and crawler-go up |
+
+## Reproducible Script
+
+The validation can be replayed with:
+
+```sh
+tests/validation/run-local-dev-install-hardening.sh
+```
+
+For the destructive fresh-install validation that drops Compose volumes before rebuilding and starting the stack:
+
+```sh
+tests/validation/run-local-dev-install-hardening.sh --fresh --yes
+```
+
+The script resolves container IDs dynamically through `docker compose ps -q <service>` when supported, then falls back to Compose service labels for Podman Compose. It does not depend on dash-style or underscore-style container names. It also polls service readiness instead of relying on a fixed sleep.
+
+## Notes
+
+- The first demo-user check accidentally ran against an old `scouter` container that had not been recreated after the image build. It created `demo@scouter.local`; the row was immediately removed with:
+
+  ```sh
+  docker exec scouter_postgres_1 psql -U scouter -d scouter -c "DELETE FROM users WHERE email = 'demo@scouter.local';"
+  ```
+
+- After forcing container recreation and stabilizing the stack, the corrected script was verified in the container and refused by default.
+- The replayable script was run with `--fresh --yes` after the manual checks. This performed `down -v --remove-orphans`, rebuilt the stack, and confirmed `jobs` / `job_logs` on a fresh Postgres volume.
+- The successful fresh run log was written to `tests/validation/local-dev-install-hardening.20260623-140945.log`. Validation logs are ignored by Git via `tests/validation/*.log`.

--- a/tests/validation/run-local-dev-install-hardening.sh
+++ b/tests/validation/run-local-dev-install-hardening.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+LOG_DIR="$ROOT/tests/validation"
+LOG_FILE="$LOG_DIR/local-dev-install-hardening.$(date +%Y%m%d-%H%M%S).log"
+COMPOSE=(docker compose -f docker-compose.local.yml)
+
+FRESH=0
+YES=0
+
+usage() {
+  cat <<'EOF'
+Usage: tests/validation/run-local-dev-install-hardening.sh [--fresh] [--yes]
+
+Runs the local dev install + hardening validation.
+
+Options:
+  --fresh  Run a destructive fresh-install check first:
+           docker compose -f docker-compose.local.yml down -v --remove-orphans
+  --yes    Do not prompt before the destructive --fresh reset.
+  --help   Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fresh) FRESH=1 ;;
+    --yes) YES=1 ;;
+    --help|-h) usage; exit 0 ;;
+    *) printf 'Unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+log() {
+  printf '\n==> %s\n' "$*" | tee -a "$LOG_FILE"
+}
+
+capture() {
+  log "$*"
+  "$@" 2>&1 | tee -a "$LOG_FILE"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+container_id() {
+  local service="$1"
+  local cid labels
+
+  cid="$("${COMPOSE[@]}" ps -q "$service" 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$cid" ]]; then
+    printf '%s\n' "$cid"
+    return 0
+  fi
+
+  # podman-compose does not support `ps -q SERVICE`, so fall back to Compose labels.
+  while IFS= read -r cid; do
+    [[ -z "$cid" ]] && continue
+    labels="$(docker inspect "$cid" --format '{{ index .Config.Labels "com.docker.compose.service" }} {{ index .Config.Labels "io.podman.compose.service" }}' 2>/dev/null || true)"
+    if [[ " $labels " == *" $service "* ]]; then
+      printf '%s\n' "$cid"
+      return 0
+    fi
+  done < <("${COMPOSE[@]}" ps -q 2>/dev/null)
+}
+
+compose_exec() {
+  local service="$1"
+  shift
+  local cid
+  cid="$(container_id "$service")"
+  if [[ -z "$cid" ]]; then
+    printf 'No running container found for service: %s\n' "$service" >&2
+    return 1
+  fi
+  docker exec "$cid" "$@"
+}
+
+wait_until() {
+  local label="$1"
+  local timeout="$2"
+  shift 2
+
+  log "Waiting for ${label} (timeout ${timeout}s)"
+  local end=$((SECONDS + timeout))
+  until "$@" >/dev/null 2>&1; do
+    if (( SECONDS >= end )); then
+      printf 'Timed out waiting for %s\n' "$label" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+postgres_ready() {
+  compose_exec postgres pg_isready -U scouter -d scouter
+}
+
+clickhouse_ready() {
+  compose_exec clickhouse clickhouse-client -q 'SELECT 1'
+}
+
+http_ready() {
+  compose_exec scouter curl -fsS -o /dev/null http://127.0.0.1:8080/login.php
+}
+
+jobs_schema_ready() {
+  local count
+  count="$(compose_exec postgres psql -U scouter -d scouter -tAc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name IN ('jobs','job_logs');")"
+  [[ "$count" == "2" ]]
+}
+
+require_cmd composer
+require_cmd php
+require_cmd bash
+require_cmd curl
+require_cmd docker
+
+mkdir -p "$LOG_DIR"
+printf '# Local dev install hardening validation\nStarted: %s\nFresh install: %s\n\n' \
+  "$(date -Iseconds)" "$FRESH" > "$LOG_FILE"
+
+if [[ "$FRESH" -eq 1 ]]; then
+  if [[ "$YES" -ne 1 ]]; then
+    printf 'This will delete Compose containers and volumes for this project (down -v). Continue? [y/N] ' >&2
+    read -r answer
+    case "$answer" in
+      y|Y|yes|YES) ;;
+      *) printf 'Aborted.\n' >&2; exit 130 ;;
+    esac
+  fi
+  capture "${COMPOSE[@]}" down -v --remove-orphans
+fi
+
+capture composer validate --strict
+capture composer install --dry-run --no-interaction --prefer-dist --optimize-autoloader
+capture composer audit --locked
+capture php -l web/diagnostic.php
+capture php -l scripts/create-demo-user.php
+capture bash -n start.sh
+capture git diff --check
+
+capture "${COMPOSE[@]}" config
+capture "${COMPOSE[@]}" build scouter worker
+capture "${COMPOSE[@]}" up -d --force-recreate --scale worker=4 --remove-orphans
+
+wait_until "PostgreSQL" 120 postgres_ready
+wait_until "ClickHouse" 120 clickhouse_ready
+wait_until "Scouter HTTP" 180 http_ready
+wait_until "jobs/job_logs schema" 120 jobs_schema_ready
+
+capture "${COMPOSE[@]}" ps
+
+capture curl -sS -I http://localhost:8080
+
+capture compose_exec postgres psql -U scouter -d scouter -c '\dt job*'
+
+log "Checking diagnostic.php over host HTTP when port forwarding is available"
+host_diag_status="$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/diagnostic.php || true)"
+printf 'host diagnostic.php HTTP status: %s\n' "${host_diag_status:-curl-failed}" | tee -a "$LOG_FILE"
+if [[ "$host_diag_status" != "404" ]]; then
+  printf 'Host diagnostic.php check did not return 404; falling back to in-container HTTP check.\n' | tee -a "$LOG_FILE"
+fi
+
+log "Checking diagnostic.php returns 404 over HTTP inside the scouter container"
+diag_status="$(compose_exec scouter curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/diagnostic.php)"
+printf 'container diagnostic.php HTTP status: %s\n' "$diag_status" | tee -a "$LOG_FILE"
+if [[ "$diag_status" != "404" ]]; then
+  printf 'Expected diagnostic.php to return 404 over HTTP, got %s\n' "$diag_status" >&2
+  exit 1
+fi
+
+capture compose_exec scouter php /app/web/diagnostic.php
+
+log "Checking create-demo-user.php refuses by default"
+set +e
+demo_output="$(compose_exec scouter php /app/scripts/create-demo-user.php 2>&1)"
+demo_code=$?
+set -e
+printf '%s\n' "$demo_output" | tee -a "$LOG_FILE"
+if [[ "$demo_code" -eq 0 ]]; then
+  printf 'Expected create-demo-user.php to fail by default, but it exited 0\n' >&2
+  exit 1
+fi
+if [[ "$demo_output" != *"Refusing to create demo admin"* ]]; then
+  printf 'Expected create-demo-user.php refusal message was not found\n' >&2
+  exit 1
+fi
+
+log "Checking demo account was not created"
+demo_count="$(compose_exec postgres psql -U scouter -d scouter -tAc "SELECT count(*) FROM users WHERE email = 'demo@scouter.local';")"
+printf 'demo@scouter.local count: %s\n' "$demo_count" | tee -a "$LOG_FILE"
+if [[ "$demo_count" != "0" ]]; then
+  printf 'Expected no demo@scouter.local user, got count %s\n' "$demo_count" >&2
+  exit 1
+fi
+
+capture compose_exec scouter ./vendor/bin/pest
+capture "${COMPOSE[@]}" logs --tail=120 scouter worker crawler-go postgres clickhouse
+capture "${COMPOSE[@]}" ps
+
+printf '\nValidation completed successfully: %s\nLog: %s\n' "$(date -Iseconds)" "$LOG_FILE" | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary

This PR adds a replayable validation script and trace for the local install hardening work split across the companion PRs:

- #51 hardens dev/debug scripts
- #52 adds the missing jobs/job_logs schema for fresh installs
- #53 improves the local dependency and Docker/Podman install path

The script lives under tests/validation and can be run in normal mode or destructive fresh-install mode.

## What the script checks

- Composer manifest, lock-file install plan, and audit
- PHP and shell syntax checks
- Compose config and image build
- fresh stack startup with force-recreated containers
- PostgreSQL, ClickHouse, Scouter HTTP, and jobs/job_logs readiness polling
- host and in-container HTTP 404 behavior for web/diagnostic.php
- CLI diagnostic still works
- create-demo-user.php refuses by default
- demo@scouter.local is not created
- Pest test suite

## Fresh install mode

The destructive fresh-volume check is explicit:

```sh
tests/validation/run-local-dev-install-hardening.sh --fresh --yes
```

This runs `docker compose -f docker-compose.local.yml down -v --remove-orphans` before rebuilding and starting the stack, so it validates the fresh PostgreSQL schema path.

## Validation

The script was run successfully locally with `--fresh --yes` after the companion fixes. The recorded run confirmed:

- jobs and job_logs existed on a fresh Postgres volume
- /diagnostic.php returned 404 from host HTTP and in-container HTTP
- create-demo-user.php refused by default and demo@scouter.local count stayed 0
- Pest suite: 392 passed, 2 skipped, 941 assertions

The generated local .log files are intentionally ignored by Git.