### PR TITLE
fix(storage): keep local exports readable

### DIFF
--- a/app/Storage/LocalStorage.php
+++ b/app/Storage/LocalStorage.php
@@ -54,7 +54,11 @@ class LocalStorage implements StorageInterface
         if (@file_put_contents($tmp, $data) === false) {
             return false;
         }
-        return @rename($tmp, $path);
+        if (!@rename($tmp, $path)) {
+            return false;
+        }
+        @chmod($path, 0644);
+        return true;
     }
 
     public function putFile(string $key, string $path, string $contentType = ''): bool
@@ -69,9 +73,14 @@ class LocalStorage implements StorageInterface
         }
         // Same filesystem → atomic rename if we own the temp; otherwise copy.
         if (@rename($path, $dest)) {
+            @chmod($dest, 0644);
             return true;
         }
-        return @copy($path, $dest);
+        if (!@copy($path, $dest)) {
+            return false;
+        }
+        @chmod($dest, 0644);
+        return true;
     }
 
     public function presignedGetUrl(string $key, int $expirySeconds, array $responseHeaders = []): ?string

--- a/tests/Unit/ExportServiceTest.php
+++ b/tests/Unit/ExportServiceTest.php
@@ -36,6 +36,19 @@ it('streams a file upload through the local backend', function () {
     expect(Storage::instance()->get('export/1/test.csv'))->toContain('1;2;3');
 });
 
+it('keeps renamed local uploads readable by the web server user', function () {
+    $src = tempnam(sys_get_temp_dir(), 'src');
+    file_put_contents($src, "a;b;c\n1;2;3\n");
+    chmod($src, 0600);
+
+    expect(Storage::instance()->putFile('export/1/private-source.csv', $src, 'text/csv'))->toBeTrue();
+
+    $dest = $this->root . '/export/1/private-source.csv';
+    $mode = fileperms($dest) & 0777;
+    expect(($mode & 0044))->toBe(0044);
+    expect(Storage::instance()->get('export/1/private-source.csv'))->toContain('1;2;3');
+});
+
 it('returns no presigned URL for the local backend (app streams instead)', function () {
     expect(Storage::instance()->presignedGetUrl('export/1/test.csv', 3600))->toBeNull();
 });


### PR DESCRIPTION
## Summary

Fix local filesystem exports so CSV files generated from temporary files remain readable by the PHP-FPM web process.

## Root cause

`LocalStorage::putFile()` uses `rename()` for same-filesystem uploads. When the source temporary file is created with restrictive permissions such as `0600`, the renamed export keeps those permissions. The export row is marked `ready`, but the download endpoint runs as the web server user and cannot read the local file, so it returns `Fichier d'export introuvable` even though the CSV exists.

## Changes

- Apply `0644` permissions after local `put()` writes.
- Apply `0644` permissions after local `putFile()` uploads, for both rename and copy paths.
- Add a regression test covering a `0600` source file renamed into local export storage.

## Validation

- `docker compose -f docker-compose.local.yml exec scouter ./vendor/bin/pest tests/Unit/ExportServiceTest.php`
- 8 tests passed, 29 assertions
- Manually confirmed a generated local export is readable by `www-data` after the fix.