### PR TITLE
fix(crawler): run sitemap analysis in ClickHouse mode

### DIFF
--- a/app/Database/ChPdo.php
+++ b/app/Database/ChPdo.php
@@ -176,7 +176,7 @@ class ChPdo
     private const PAGE_COLS = [
         'crawl_id', 'id', 'date', 'domain', 'url', 'depth', 'code', 'response_time',
         'outlinks', 'content_type', 'redirect_to', 'crawled', 'compliant', 'noindex',
-        'nofollow', 'canonical', 'canonical_value', 'external', 'blocked', 'title', 'h1',
+        'nofollow', 'canonical', 'canonical_value', 'external', 'blocked', 'in_crawl', 'title', 'h1',
         'metadesc', 'extracts', 'simhash', 'is_html', 'h1_multiple', 'headings_missing',
         'schemas', 'word_count',
     ];
@@ -219,7 +219,6 @@ class ChPdo
             $joins .= " LEFT JOIN (SELECT crawl_id AS _gcid, id AS _gid, generation "
                 . "FROM {$this->db}.page_generation WHERE crawl_id IN ({$in}) LIMIT 1 BY (crawl_id, id)) g ON g._gcid = p.crawl_id AND g._gid = p.id";
         }
-        $cols[] = "toUInt8(1) AS in_crawl";
         return "(SELECT " . implode(', ', $cols)
             . " FROM (SELECT * FROM {$this->db}.pages WHERE crawl_id IN ({$in}) LIMIT 1 BY (crawl_id, id)) p"
             . $joins . ")";

--- a/crawler-go/cmd/scouter-crawler/main.go
+++ b/crawler-go/cmd/scouter-crawler/main.go
@@ -428,7 +428,8 @@ func runJob(ctx context.Context, pool *db.Pool, ch *db.CH, mgr *jobs.Manager, j 
 	// Post-processing in ClickHouse (PageRank/inlinks/semantic/duplicate/redirect)
 	// → derived tables. Runs in addition to PG during the dual-write transition.
 	if ch != nil {
-		chpp := postprocess.NewCHRunner(ch, rec.ID, postprocess.RespectNofollowFromConfig(rec.Config), logf)
+		chpp := postprocess.NewCHRunner(ch, rec.ID, postprocess.RespectNofollowFromConfig(rec.Config), rec.Config, rec.Domain, logf)
+		chpp.SitemapFetch = pp.SitemapFetch
 		ppFailures = append(ppFailures, chpp.Run(ctx)...)
 		// In full-CH mode the PG post-processor is skipped, so write the
 		// duplicate/redirect scorecard stats back to crawls.* from ClickHouse.

--- a/crawler-go/internal/backfill/backfill.go
+++ b/crawler-go/internal/backfill/backfill.go
@@ -454,8 +454,9 @@ func (b *Backfiller) migrate(ctx context.Context, crawlID int, withHTML bool) er
 
 	// Post-processing in ClickHouse (page_metrics, duplicate, redirect).
 	var cfg []byte
-	_ = b.pool.QueryRow(ctx, "SELECT config FROM crawls WHERE id=$1", crawlID).Scan(&cfg)
-	postprocess.NewCHRunner(b.ch, crawlID, postprocess.RespectNofollowFromConfig(cfg), b.logf).Run(ctx)
+	var domain string
+	_ = b.pool.QueryRow(ctx, "SELECT config, domain FROM crawls WHERE id=$1", crawlID).Scan(&cfg, &domain)
+	postprocess.NewCHRunner(b.ch, crawlID, postprocess.RespectNofollowFromConfig(cfg), cfg, domain, b.logf).Run(ctx)
 	b.SyncStats(ctx, crawlID) // write back duplicate/redirect scorecard stats
 
 	// Completeness check before flipping the read store.
@@ -488,8 +489,8 @@ func (b *Backfiller) pages(ctx context.Context, crawlID int) error {
 	rows, err := b.pool.Query(ctx, `
 		SELECT id, domain, url, depth, code, response_time, outlinks, content_type, redirect_to,
 		       crawled, compliant, noindex, nofollow, canonical, canonical_value, external, blocked,
-		       title, h1, metadesc, extracts, simhash, is_html, h1_multiple, headings_missing, schemas, word_count
-		FROM pages WHERE crawl_id=$1 AND in_crawl=true AND (crawled=true OR external=true)`, crawlID)
+		       in_crawl, title, h1, metadesc, extracts, simhash, is_html, h1_multiple, headings_missing, schemas, word_count
+		FROM pages WHERE crawl_id=$1 AND ((in_crawl=true AND (crawled=true OR external=true)) OR in_sitemap=true)`, crawlID)
 	if err != nil {
 		return err
 	}
@@ -500,20 +501,20 @@ func (b *Backfiller) pages(ctx context.Context, crawlID int) error {
 		// non-HTML pages, code on uncrawled redirect targets) are scanned into
 		// pointers and coalesced to ''/0 for ClickHouse (no NULLs in those CH cols).
 		var (
-			id                                                                  string
-			domain, url, contentType, redirectTo, canonicalValue, title, h1, metadesc *string
-			depth, outlinks, wordCount                                          int
-			code                                                                *int
-			responseTime                                                        *float64
-			crawled, compliant, noindex, nofollow, canonical, external, blocked bool
-			isHTML, h1Multiple, headingsMissing                                 *bool
-			extracts                                                            []byte
-			simhash                                                             *int64
-			schemas                                                             []string
+			id                                                                           string
+			domain, url, contentType, redirectTo, canonicalValue, title, h1, metadesc    *string
+			depth, outlinks, wordCount                                                   int
+			code                                                                         *int
+			responseTime                                                                 *float64
+			crawled, compliant, noindex, nofollow, canonical, external, blocked, inCrawl bool
+			isHTML, h1Multiple, headingsMissing                                          *bool
+			extracts                                                                     []byte
+			simhash                                                                      *int64
+			schemas                                                                      []string
 		)
 		if err := rows.Scan(&id, &domain, &url, &depth, &code, &responseTime, &outlinks, &contentType, &redirectTo,
 			&crawled, &compliant, &noindex, &nofollow, &canonical, &canonicalValue, &external, &blocked,
-			&title, &h1, &metadesc, &extracts, &simhash, &isHTML, &h1Multiple, &headingsMissing, &schemas, &wordCount); err != nil {
+			&inCrawl, &title, &h1, &metadesc, &extracts, &simhash, &isHTML, &h1Multiple, &headingsMissing, &schemas, &wordCount); err != nil {
 			return err
 		}
 		extractsMap := map[string]string{}
@@ -536,7 +537,7 @@ func (b *Backfiller) pages(ctx context.Context, crawlID int) error {
 			"code": codeV, "response_time": rtV, "outlinks": outlinks, "content_type": ps(contentType),
 			"redirect_to": ps(redirectTo), "crawled": b2i(crawled), "compliant": b2i(compliant), "noindex": b2i(noindex),
 			"nofollow": b2i(nofollow), "canonical": b2i(canonical), "canonical_value": ps(canonicalValue),
-			"external": b2i(external), "blocked": b2i(blocked), "title": ps(title), "h1": ps(h1), "metadesc": ps(metadesc),
+			"external": b2i(external), "blocked": b2i(blocked), "in_crawl": b2i(inCrawl), "title": ps(title), "h1": ps(h1), "metadesc": ps(metadesc),
 			"extracts": extractsMap, "simhash": simhash, "is_html": pb2i(isHTML), "h1_multiple": pb2i(h1Multiple),
 			"headings_missing": pb2i(headingsMissing), "schemas": schemas, "word_count": wordCount,
 		})

--- a/crawler-go/internal/crawl/ch_store.go
+++ b/crawler-go/internal/crawl/ch_store.go
@@ -73,6 +73,7 @@ type chPageRow struct {
 	CanonicalValue  string            `json:"canonical_value"`
 	External        int               `json:"external"`
 	Blocked         int               `json:"blocked"`
+	InCrawl         int               `json:"in_crawl"`
 	Title           string            `json:"title"`
 	H1              string            `json:"h1"`
 	MetaDesc        string            `json:"metadesc"`
@@ -153,7 +154,7 @@ func (s *CHStore) AddExternalPage(id, domain, url string, depth int, blocked boo
 	s.seenExt[id] = struct{}{}
 	s.pages = append(s.pages, chPageRow{
 		CrawlID: s.crawlID, ID: id, Domain: domain, URL: url, Depth: depth,
-		Crawled: 0, External: 1, Blocked: b2i(blocked),
+		Crawled: 0, External: 1, Blocked: b2i(blocked), InCrawl: 1,
 		Extracts: map[string]string{}, Schemas: []string{},
 	})
 	flush := len(s.pages) >= chBatch

--- a/crawler-go/internal/crawl/store.go
+++ b/crawler-go/internal/crawl/store.go
@@ -93,7 +93,8 @@ func (e *Engine) storePage(ctx context.Context, p model.Page, depth int) error {
 		ContentType: truncateStr(p.ContentType, 100), RedirectTo: p.RedirectTo,
 		Crawled: 1, Compliant: b2i(compliant), Noindex: b2i(p.Noindex), Nofollow: b2i(p.Nofollow),
 		Canonical: b2i(isCanonical), CanonicalValue: p.CanonicalURL, External: 0, Blocked: b2i(blocked),
-		Title: p.Title, H1: p.H1, MetaDesc: p.MetaDesc, Extracts: p.CustomExtract, Simhash: p.Simhash,
+		InCrawl: 1,
+		Title:   p.Title, H1: p.H1, MetaDesc: p.MetaDesc, Extracts: p.CustomExtract, Simhash: p.Simhash,
 		IsHTML: b2i(p.IsHTML), H1Multiple: b2i(p.H1Multiple), HeadingsMissing: b2i(p.HeadingsMissing),
 		Schemas: p.Schemas, WordCount: p.WordCount,
 	})

--- a/crawler-go/internal/db/schema.sql
+++ b/crawler-go/internal/db/schema.sql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS scouter.pages
     canonical_value   String,
     external          UInt8,
     blocked           UInt8,
+    in_crawl          UInt8 DEFAULT 1,
     title             String,
     h1                String,
     metadesc          String,
@@ -69,6 +70,8 @@ CREATE TABLE IF NOT EXISTS scouter.pages
 ENGINE = ReplacingMergeTree(date)
 PARTITION BY crawl_id
 ORDER BY (crawl_id, id);
+
+ALTER TABLE scouter.pages ADD COLUMN IF NOT EXISTS in_crawl UInt8 DEFAULT 1;
 
 -- ---------------------------------------------------------------------------
 -- links — every <a>/redirect/canonical edge as it appears (no dedup).

--- a/crawler-go/internal/postprocess/clickhouse.go
+++ b/crawler-go/internal/postprocess/clickhouse.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"scouter-crawler/internal/analysis"
 	"scouter-crawler/internal/db"
 )
 
@@ -23,7 +24,14 @@ type CHRunner struct {
 	ch              *db.CH
 	crawlID         int
 	respectNofollow bool
+	config          []byte
+	domain          string
+	sitemapTable    string
 	logf            func(string, ...any)
+
+	// SitemapFetch, if set, fetches new in-scope sitemap-only URLs through a
+	// skip-link-extraction pass before metrics are built.
+	SitemapFetch func(ctx context.Context, urls, domains []string) error
 }
 
 // RespectNofollowFromConfig reads advanced.respect_nofollow (default true, like
@@ -33,14 +41,14 @@ func RespectNofollowFromConfig(raw []byte) bool {
 }
 
 // NewCHRunner returns a CH post-processor, or nil if ch is nil (CH disabled).
-func NewCHRunner(ch *db.CH, crawlID int, respectNofollow bool, logf func(string, ...any)) *CHRunner {
+func NewCHRunner(ch *db.CH, crawlID int, respectNofollow bool, config []byte, domain string, logf func(string, ...any)) *CHRunner {
 	if ch == nil {
 		return nil
 	}
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
-	return &CHRunner{ch: ch, crawlID: crawlID, respectNofollow: respectNofollow, logf: logf}
+	return &CHRunner{ch: ch, crawlID: crawlID, respectNofollow: respectNofollow, config: config, domain: domain, logf: logf}
 }
 
 func (r *CHRunner) t(name string) string { return r.ch.DB() + "." + name }
@@ -67,6 +75,7 @@ func (r *CHRunner) Run(ctx context.Context) []string {
 		name string
 		fn   func(context.Context) error
 	}{
+		{"ch-sitemap", r.sitemapAnalysis},
 		{"ch-pagerank+metrics", r.buildMetrics},
 		{"ch-duplicate", r.duplicateAnalysis},
 		{"ch-redirect", r.redirectChainAnalysis},
@@ -76,6 +85,11 @@ func (r *CHRunner) Run(ctx context.Context) []string {
 		{"ch-optimize", r.optimizeFinal},
 	}
 	var failed []string
+	defer func() {
+		if r.sitemapTable != "" {
+			_ = r.ch.Exec(context.Background(), "DROP TABLE IF EXISTS "+r.sitemapTable)
+		}
+	}()
 	for _, s := range steps {
 		if err := s.fn(ctx); err != nil {
 			r.logf("clickhouse post-processing error in %s: %v", s.name, err)
@@ -85,6 +99,155 @@ func (r *CHRunner) Run(ctx context.Context) []string {
 		}
 	}
 	return failed
+}
+
+// sitemapAnalysis is the ClickHouse equivalent of Runner.sitemapAnalysis. It
+// parses configured sitemaps, records their page IDs in a Memory table used by
+// buildMetrics, fetches new in-scope sitemap URLs, and inserts placeholders for
+// URLs that remain sitemap-only.
+func (r *CHRunner) sitemapAnalysis(ctx context.Context) error {
+	sitemapURLs := advancedStrings(r.config, "sitemap_urls")
+	clean := sitemapURLs[:0]
+	for _, u := range sitemapURLs {
+		if t := strings.TrimSpace(u); t != "" {
+			clean = append(clean, t)
+		}
+	}
+	if len(clean) == 0 {
+		return nil
+	}
+
+	result := analysis.NewSitemapParser().Parse(clean)
+	if len(result.URLs) == 0 {
+		return nil
+	}
+
+	idToURL := make(map[string]string, len(result.URLs))
+	ids := make([]string, 0, len(result.URLs))
+	for _, u := range result.URLs {
+		id := analysis.PageID(u)
+		if _, seen := idToURL[id]; seen {
+			continue
+		}
+		idToURL[id] = u
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	if err := r.createSitemapTable(ctx, ids); err != nil {
+		return err
+	}
+
+	existing, err := r.existingSitemapIDs(ctx)
+	if err != nil {
+		return err
+	}
+
+	allowed := generalStrings(r.config, "domains")
+	if len(allowed) == 0 && strings.TrimSpace(r.domain) != "" {
+		allowed = []string{r.domain}
+	}
+
+	var newInScopeURLs []string
+	for id, u := range idToURL {
+		if existing[id] {
+			continue
+		}
+		if urlInScope(u, allowed) {
+			newInScopeURLs = append(newInScopeURLs, u)
+		}
+	}
+
+	if len(newInScopeURLs) > 0 && r.SitemapFetch != nil {
+		if err := r.SitemapFetch(ctx, newInScopeURLs, allowed); err != nil {
+			r.logf("clickhouse sitemap fetch error: %v", err)
+		}
+		existing, err = r.existingSitemapIDs(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	inScopeOnly := map[string]string{}
+	outScopeOnly := map[string]string{}
+	for id, u := range idToURL {
+		if existing[id] {
+			continue
+		}
+		if urlInScope(u, allowed) {
+			inScopeOnly[id] = u
+		} else {
+			outScopeOnly[id] = u
+		}
+	}
+	if err := r.insertSitemapOnly(ctx, inScopeOnly, false); err != nil {
+		return err
+	}
+	return r.insertSitemapOnly(ctx, outScopeOnly, true)
+}
+
+func (r *CHRunner) createSitemapTable(ctx context.Context, ids []string) error {
+	r.sitemapTable = r.t("sitemap_ids_" + r.cid())
+	if err := r.ch.Exec(ctx, "DROP TABLE IF EXISTS "+r.sitemapTable); err != nil {
+		return err
+	}
+	if err := r.ch.Exec(ctx, "CREATE TABLE "+r.sitemapTable+" (id FixedString(8)) ENGINE = Memory"); err != nil {
+		return err
+	}
+	batch := make([]any, 0, 1000)
+	for _, id := range ids {
+		batch = append(batch, map[string]any{"id": id})
+		if len(batch) >= 1000 {
+			if err := r.ch.InsertJSONEachRow(ctx, r.sitemapTable, batch); err != nil {
+				return err
+			}
+			batch = batch[:0]
+		}
+	}
+	return r.ch.InsertJSONEachRow(ctx, r.sitemapTable, batch)
+}
+
+func (r *CHRunner) existingSitemapIDs(ctx context.Context) (map[string]bool, error) {
+	existing := map[string]bool{}
+	if r.sitemapTable == "" {
+		return existing, nil
+	}
+	rows, err := r.ch.QueryTSV(ctx, "SELECT toString(id) FROM "+r.pd()+" WHERE id IN (SELECT id FROM "+r.sitemapTable+")")
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if len(row) > 0 {
+			existing[strings.TrimSpace(row[0])] = true
+		}
+	}
+	return existing, nil
+}
+
+func (r *CHRunner) insertSitemapOnly(ctx context.Context, idToURL map[string]string, external bool) error {
+	if len(idToURL) == 0 {
+		return nil
+	}
+	batch := make([]any, 0, 1000)
+	for id, u := range idToURL {
+		batch = append(batch, map[string]any{
+			"crawl_id": r.crawlID, "id": id, "domain": smDomain(u), "url": truncate(u, 2083), "depth": -1,
+			"code": 0, "response_time": 0, "outlinks": 0, "content_type": "", "redirect_to": "",
+			"crawled": 0, "compliant": 0, "noindex": 0, "nofollow": 0, "canonical": 1, "canonical_value": "",
+			"external": b2iCH(external), "blocked": 0, "in_crawl": 0, "title": "", "h1": "", "metadesc": "",
+			"extracts": map[string]string{}, "simhash": nil, "is_html": 0, "h1_multiple": 0,
+			"headings_missing": 0, "schemas": []string{}, "word_count": 0,
+		})
+		if len(batch) >= 1000 {
+			if err := r.ch.InsertJSONEachRow(ctx, r.t("pages"), batch); err != nil {
+				return err
+			}
+			batch = batch[:0]
+		}
+	}
+	return r.ch.InsertJSONEachRow(ctx, r.t("pages"), batch)
 }
 
 // buildMetrics computes PageRank into a Memory table, then assembles page_metrics
@@ -114,9 +277,14 @@ func (r *CHRunner) buildMetrics(ctx context.Context) error {
 	inlinksSub := `(SELECT target AS tid, count() AS inlinks FROM ` + r.t("links") +
 		` WHERE crawl_id = ` + cid + ` GROUP BY target)`
 
+	inSitemapExpr := "0"
+	if r.sitemapTable != "" {
+		inSitemapExpr = `if(p.id IN (SELECT id FROM ` + r.sitemapTable + `), 1, 0)`
+	}
+
 	sql := `INSERT INTO ` + r.t("page_metrics") +
 		` (crawl_id, id, inlinks, pri, title_status, h1_status, metadesc_status, in_sitemap)
-		SELECT ` + cid + `, p.id, il.inlinks, pr.pr, st.title_status, st.h1_status, st.metadesc_status, 0
+		SELECT ` + cid + `, p.id, il.inlinks, pr.pr, st.title_status, st.h1_status, st.metadesc_status, ` + inSitemapExpr + `
 		FROM ` + r.pd() + ` p
 		LEFT JOIN ` + inlinksSub + ` il ON il.tid = p.id
 		LEFT JOIN ` + r.t("pr_cur_"+cid) + ` pr ON pr.id = p.id
@@ -155,7 +323,8 @@ func (r *CHRunner) computePageRank(ctx context.Context) error {
 		}
 	}
 
-	pagesCountStr, err := r.ch.QueryScalar(ctx, "SELECT count() FROM "+r.pd())
+	inCrawlPages := r.pd() + " WHERE in_crawl = 1"
+	pagesCountStr, err := r.ch.QueryScalar(ctx, "SELECT count() FROM "+inCrawlPages)
 	if err != nil {
 		return err
 	}
@@ -171,7 +340,7 @@ func (r *CHRunner) computePageRank(ctx context.Context) error {
 
 	if !hasLinks {
 		// No graph: pri stays 0 (matches PG, which skips the update entirely).
-		return r.ch.Exec(ctx, "INSERT INTO "+prCur+" SELECT id, 0, 0 FROM "+r.pd())
+		return r.ch.Exec(ctx, "INSERT INTO "+prCur+" SELECT id, 0, 0 FROM "+inCrawlPages)
 	}
 
 	initPR := 1.0 / float64(pagesCount)
@@ -179,7 +348,8 @@ func (r *CHRunner) computePageRank(ctx context.Context) error {
 	if err := r.ch.Exec(ctx, `INSERT INTO `+prCur+`
 		SELECT p.id, `+f(initPR)+`, ol.c
 		FROM `+r.pd()+` p
-		LEFT JOIN `+outlinksSub+` ol ON ol.sid = p.id`); err != nil {
+		LEFT JOIN `+outlinksSub+` ol ON ol.sid = p.id
+		WHERE p.in_crawl = 1`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Add a `ch-sitemap` step to the ClickHouse post-processing pipeline.
- Parse configured sitemap URLs in ClickHouse-only mode and mark sitemap membership in `page_metrics.in_sitemap`.
- Preserve the crawl-vs-sitemap distinction in ClickHouse by adding `pages.in_crawl`.
- Insert sitemap-only placeholder pages in ClickHouse so the sitemap report can count URLs that were declared in the sitemap but not discovered by the crawl.
- Update ClickHouse backfill and report table translation to carry the new `in_crawl` signal.

## Root cause

When `CLICKHOUSE_DROP_PG=1`, the PostgreSQL post-processor is skipped. Sitemap analysis only existed in that PostgreSQL post-processing path, while the ClickHouse post-processor only built metrics, duplicate clusters, redirects, and optimization. As a result, reports reading from ClickHouse always saw `in_sitemap = 0`.

## Impact

Sitemap reports now work for ClickHouse-only crawls. New crawls can show URLs found in both crawl and sitemap, URLs only in the sitemap, and indexable crawl URLs missing from the sitemap.

## Validation

- `docker compose -f docker-compose.local.yml run --rm --no-deps crawler-go go test ./...`
- `php -l app/Database/ChPdo.php`
- `git diff --check`
- Local ClickHouse schema check confirmed `scouter.pages.in_crawl UInt8 DEFAULT 1`.
