### PR TITLE
fix: sitemap-only URLs never fetched in full-CH mode + categorization lost on a new crawl

### DIFF
--- a/app/Database/CategorizationRepository.php
+++ b/app/Database/CategorizationRepository.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Database;
+
+use PDO;
+
+/**
+ * Categorization config of a crawl (the URL-segmentation YAML).
+ *
+ * A crawl FREEZES the project's rules into its own `categorization_config` row at
+ * creation; editing the segments upserts that row for every crawl of the project
+ * (see CategorizationController). So "what a new crawl should start from" is a
+ * three-step lookup, and getting it wrong means the user silently loses their
+ * segmentation and lands back on the generic cat.yml template.
+ *
+ * This lives here because BOTH creation paths need it and used to disagree: the
+ * UI inherited (ProjectController::create), while the public API / MCP
+ * `create_crawl` always applied the blank template — same project, same domain,
+ * config gone.
+ *
+ * @package    Scouter
+ * @subpackage Database
+ */
+class CategorizationRepository
+{
+    private PDO $db;
+
+    public function __construct(?PDO $db = null)
+    {
+        $this->db = $db ?: PostgresDatabase::getInstance()->getConnection();
+    }
+
+    /**
+     * The YAML a brand-new crawl of this project should start with:
+     *
+     *   1. the most recent OTHER crawl of the project that has one — the live
+     *      state of the user's segmentation,
+     *   2. else the project-level default (`projects.categorization_config`),
+     *   3. else the cat.yml template with {dom} filled in (first crawl ever).
+     *
+     * Returns null only when even the template is unavailable.
+     */
+    public function inheritedConfig(int $projectId, string $domain, ?int $excludeCrawlId = null): ?string
+    {
+        // The exclusion is appended rather than bound as a nullable param: PDO
+        // rewrites named parameters client-side, and `::int` casts next to them
+        // are a known source of parser confusion.
+        $sql = "SELECT cc.config
+                FROM categorization_config cc
+                JOIN crawls c ON c.id = cc.crawl_id
+                WHERE c.project_id = :pid
+                  AND cc.config IS NOT NULL AND cc.config <> ''";
+        $params = [':pid' => $projectId];
+        if ($excludeCrawlId !== null) {
+            $sql .= " AND cc.crawl_id <> :cid";
+            $params[':cid'] = $excludeCrawlId;
+        }
+        $sql .= " ORDER BY c.id DESC LIMIT 1";
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute($params);
+        $row = $stmt->fetch(PDO::FETCH_OBJ);
+        if ($row && !empty($row->config)) {
+            return (string) $row->config;
+        }
+
+        $stmt = $this->db->prepare("SELECT categorization_config FROM projects WHERE id = :pid");
+        $stmt->execute([':pid' => $projectId]);
+        $row = $stmt->fetch(PDO::FETCH_OBJ);
+        if ($row && !empty($row->categorization_config)) {
+            return (string) $row->categorization_config;
+        }
+
+        return self::template($domain);
+    }
+
+    /** The default cat.yml template with {dom} substituted, or null if missing. */
+    public static function template(string $domain): ?string
+    {
+        $path = dirname(__DIR__, 2) . '/cat.yml';
+        if (!file_exists($path)) {
+            return null;
+        }
+        $tpl = file_get_contents($path);
+        return $tpl ? str_replace('{dom}', $domain, $tpl) : null;
+    }
+
+    /** Store a crawl's categorization snapshot. */
+    public function setForCrawl(int $crawlId, string $yaml): void
+    {
+        $stmt = $this->db->prepare("
+            INSERT INTO categorization_config (crawl_id, config)
+            VALUES (:crawl_id, :config)
+            ON CONFLICT (crawl_id) DO UPDATE SET config = :config2
+        ");
+        $stmt->execute([':crawl_id' => $crawlId, ':config' => $yaml, ':config2' => $yaml]);
+    }
+
+    /**
+     * Seed a freshly created crawl with the project's current segmentation.
+     * No-op when there is nothing to inherit and no template on disk.
+     */
+    public function seedNewCrawl(int $crawlId, int $projectId, string $domain): void
+    {
+        $yaml = $this->inheritedConfig($projectId, $domain, $crawlId);
+        if ($yaml !== null && $yaml !== '') {
+            $this->setForCrawl($crawlId, $yaml);
+        }
+    }
+}

--- a/app/Http/Controllers/ApiV1Controller.php
+++ b/app/Http/Controllers/ApiV1Controller.php
@@ -931,7 +931,7 @@ class ApiV1Controller extends Controller
             'project_id'  => $projectId,
         ]);
 
-        $this->applyDefaultCategorization($crawlId, $domain);
+        $this->applyDefaultCategorization($crawlId, $projectId, $domain);
 
         // Queue the job (same path as the UI's /crawls/start).
         $jobManager = new JobManager();
@@ -1287,20 +1287,17 @@ class ApiV1Controller extends Controller
         return ['general' => $generalOut, 'advanced' => $advancedOut];
     }
 
-    /** Apply the default categorization template (cat.yml) to a new crawl, same as the UI. */
-    private function applyDefaultCategorization(int $crawlId, string $domain): void
+    /**
+     * Seed a new crawl's categorization, same as the UI.
+     *
+     * This used to apply the blank cat.yml template unconditionally, so creating
+     * a crawl through the API (or the MCP `create_crawl` tool) in a project that
+     * already had a segmentation silently threw it away. It now goes through the
+     * same inheritance chain as ProjectController::create.
+     */
+    private function applyDefaultCategorization(int $crawlId, int $projectId, string $domain): void
     {
-        $catYmlPath = dirname(__DIR__, 3) . '/cat.yml';
-        if (!file_exists($catYmlPath)) return;
-        $catYaml = file_get_contents($catYmlPath);
-        if (!$catYaml) return;
-        $catYaml = str_replace('{dom}', $domain, $catYaml);
-        $stmt = $this->db->prepare("
-            INSERT INTO categorization_config (crawl_id, config)
-            VALUES (:crawl_id, :config)
-            ON CONFLICT (crawl_id) DO UPDATE SET config = :config2
-        ");
-        $stmt->execute([':crawl_id' => $crawlId, ':config' => $catYaml, ':config2' => $catYaml]);
+        (new \App\Database\CategorizationRepository($this->db))->seedNewCrawl($crawlId, $projectId, $domain);
     }
 
     /** Resolve {id} → an accessible crawl object, or send 404/403 and return null. */

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -209,8 +209,26 @@ class ProjectController extends Controller
             }
         }
 
-        // Créer ou récupérer le projet pour ce domaine
-        $projectId = $this->projects->getOrCreate($this->userId, $domain);
+        // Projet cible du crawl.
+        //
+        // Quand la requête vient de la page d'un projet ("nouveau crawl" dans un
+        // projet existant), elle envoie project_id : on rattache le crawl À CE
+        // projet. Sans ça on retombait sur getOrCreate(userId, domaine du start
+        // URL), qui re-déduit le projet du domaine — et se trompe dès que :
+        //   - l'URL de départ ne matche pas EXACTEMENT le nom du projet
+        //     (www.exemple.fr vs exemple.fr, un sous-domaine, une autre section),
+        //   - ou que le projet est partagé et n'appartient pas à l'utilisateur
+        //     (getOrCreate ne regarde que les projets dont il est propriétaire).
+        // Dans les deux cas un projet vide était créé à la volée : plus d'historique
+        // à hériter, donc la catégorisation retombait sur le template cat.yml
+        // générique et l'utilisateur perdait sa config à chaque nouveau crawl.
+        $requestedProjectId = (int) $request->get('project_id', 0);
+        if ($requestedProjectId > 0) {
+            $this->auth->requireProjectManagement($requestedProjectId);
+            $projectId = $requestedProjectId;
+        } else {
+            $projectId = $this->projects->getOrCreate($this->userId, $domain);
+        }
 
         // Générer le path unique pour ce crawl
         $projectDir = $domain . '-' . date('Ymd') . '-' . date('His');
@@ -271,59 +289,12 @@ class ProjectController extends Controller
             'project_id' => $projectId
         ]);
         
-        // Catégorisation du nouveau crawl : si le projet a déjà un historique, on
-        // HÉRITE de la config du dernier crawl (categorization_config est stockée
-        // par crawl, et l'édition la met à jour là) — sinon fallback sur la config
-        // par défaut du projet, puis sur le template cat.yml (tout premier crawl).
-        $db = \App\Database\PostgresDatabase::getInstance()->getConnection();
-        $catYaml = null;
+        // Catégorisation du nouveau crawl : héritée du dernier crawl du projet,
+        // sinon de la config projet, sinon du template cat.yml (premier crawl).
+        // Logique partagée avec l'API v1 / MCP (cf. CategorizationRepository).
+        (new \App\Database\CategorizationRepository())->seedNewCrawl($crawlId, $projectId, $domain);
 
-        // 1) Dernier crawl du même projet qui possède une catégorisation.
-        $prev = $db->prepare("
-            SELECT cc.config
-            FROM categorization_config cc
-            JOIN crawls c ON c.id = cc.crawl_id
-            WHERE c.project_id = :pid AND cc.crawl_id <> :cid
-              AND cc.config IS NOT NULL AND cc.config <> ''
-            ORDER BY c.id DESC
-            LIMIT 1
-        ");
-        $prev->execute([':pid' => $projectId, ':cid' => $crawlId]);
-        $prevRow = $prev->fetch(\PDO::FETCH_OBJ);
-        if ($prevRow && !empty($prevRow->config)) {
-            $catYaml = $prevRow->config;
-        }
 
-        // 2) Fallback : config de catégorisation par défaut du projet.
-        if ($catYaml === null) {
-            $pstmt = $db->prepare("SELECT categorization_config FROM projects WHERE id = :pid");
-            $pstmt->execute([':pid' => $projectId]);
-            $prow = $pstmt->fetch(\PDO::FETCH_OBJ);
-            if ($prow && !empty($prow->categorization_config)) {
-                $catYaml = $prow->categorization_config;
-            }
-        }
-
-        // 3) Fallback : template cat.yml (tout premier crawl d'un nouveau projet).
-        if ($catYaml === null) {
-            $catYmlPath = dirname(__DIR__, 3) . '/cat.yml';
-            if (file_exists($catYmlPath)) {
-                $tpl = file_get_contents($catYmlPath);
-                if ($tpl) {
-                    $catYaml = str_replace('{dom}', $domain, $tpl);
-                }
-            }
-        }
-
-        if ($catYaml !== null && $catYaml !== '') {
-            $stmt = $db->prepare("
-                INSERT INTO categorization_config (crawl_id, config)
-                VALUES (:crawl_id, :config)
-                ON CONFLICT (crawl_id) DO UPDATE SET config = :config2
-            ");
-            $stmt->execute([':crawl_id' => $crawlId, ':config' => $catYaml, ':config2' => $catYaml]);
-        }
-        
         $this->success([
             'project_id' => $projectId,
             'crawl_id' => $crawlId,

--- a/app/bin/scheduler.php
+++ b/app/bin/scheduler.php
@@ -9,8 +9,13 @@
  * If cron is late, the schedule is caught up on the next pass.
  */
 
+// Composer autoloader (like worker.php / the other bin scripts): this file used
+// to hand-require the single class it needed, which silently breaks the moment
+// it touches any other App\ class.
+require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../Database/PostgresDatabase.php';
 
+use App\Database\CategorizationRepository;
 use App\Database\PostgresDatabase;
 
 echo "[Scheduler] " . date('Y-m-d H:i:s') . " — checking schedules\n";
@@ -97,7 +102,9 @@ foreach ($dueSchedules as $schedule) {
     // Create partitions for the new crawl
     $db->exec("SELECT create_crawl_partitions({$crawlId})");
 
-    // Copy categorization config if present
+    // Copy the schedule's categorization snapshot when it has one; otherwise fall
+    // back to the project's current segmentation (same inheritance the UI and the
+    // API use) rather than leaving the crawl with no categorization at all.
     if (!empty($schedule->categorization_config)) {
         $stmt = $db->prepare("
             INSERT INTO categorization_config (crawl_id, config)
@@ -105,6 +112,8 @@ foreach ($dueSchedules as $schedule) {
             ON CONFLICT (crawl_id) DO UPDATE SET config = EXCLUDED.config
         ");
         $stmt->execute([':crawl_id' => $crawlId, ':config' => $schedule->categorization_config]);
+    } else {
+        (new CategorizationRepository($db))->seedNewCrawl($crawlId, (int) $pid, $domain);
     }
 
     // Create job for worker to pick up

--- a/crawler-go/cmd/scouter-crawler/main.go
+++ b/crawler-go/cmd/scouter-crawler/main.go
@@ -434,6 +434,12 @@ func runJob(ctx context.Context, pool *db.Pool, ch *db.CH, mgr *jobs.Manager, j 
 	// → derived tables. Runs in addition to PG during the dual-write transition.
 	if ch != nil {
 		chpp := postprocess.NewCHRunner(ch, pool, rec.ID, postprocess.RespectNofollowFromConfig(rec.Config), logf)
+		// Same skip-link-extraction pass the PG post-processor uses for URLs only
+		// the sitemap knows about. It has to be handed to the CH runner too: in
+		// full-CH mode pp.Run() never executes, so without this the in-scope
+		// sitemap-only URLs were recorded as placeholders and never fetched —
+		// countable, but with no status code, no title, nothing actionable.
+		chpp.SitemapFetch = pp.SitemapFetch
 		ppFailures = append(ppFailures, chpp.Run(ctx)...)
 		// In full-CH mode the PG post-processor is skipped, so write the
 		// duplicate/redirect scorecard stats back to crawls.* from ClickHouse.

--- a/crawler-go/internal/postprocess/clickhouse.go
+++ b/crawler-go/internal/postprocess/clickhouse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/bits"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -30,6 +31,13 @@ type CHRunner struct {
 	// sitemapTable is the Memory table of in_sitemap page ids built by loadSitemap;
 	// buildMetrics joins it to flag page_metrics.in_sitemap. Empty = no sitemap.
 	sitemapTable string
+
+	// SitemapFetch, if set, crawls the in-scope URLs that only the sitemap knows
+	// about (skip-link-extraction pass) so they land as real pages with a status
+	// code instead of empty placeholders. The PG post-processor has always done
+	// this; in full-ClickHouse mode (CLICKHOUSE_DROP_PG=1) it is skipped, so
+	// without this hook those URLs were never fetched at all.
+	SitemapFetch func(ctx context.Context, urls, domains []string) error
 }
 
 // RespectNofollowFromConfig reads advanced.respect_nofollow (default true, like
@@ -161,8 +169,10 @@ func (r *CHRunner) buildMetrics(ctx context.Context) error {
 // sitemap(s) itself, then:
 //
 //  1. loads every sitemap page id into a Memory table that buildMetrics joins to
-//     flag page_metrics.in_sitemap (crawled pages that appear in the sitemap), and
-//  2. inserts the sitemap-only URLs (in the sitemap but not reached by the crawl)
+//     flag page_metrics.in_sitemap (crawled pages that appear in the sitemap),
+//  2. FETCHES the in-scope URLs the crawl never reached (SitemapFetch), so a URL
+//     declared only in the sitemap still gets a real status code / title, and
+//  3. inserts what remains — URLs out of scope, or that could not be fetched —
 //     into CH `pages` as depth = -1 placeholders, so the read shim classifies them
 //     in_crawl = FALSE and the "sitemap only" / "total sitemap" counts are complete.
 //
@@ -232,26 +242,50 @@ func (r *CHRunner) loadSitemap(ctx context.Context) error {
 	}
 	r.sitemapTable = tbl
 
-	// 2) which sitemap ids already exist as CH pages (crawled)? the rest become
-	//    depth -1 placeholders. Skipping the existing ones means we never write a
-	//    second row per id (which would corrupt duplicate detection / in_crawl).
-	existing := map[string]bool{}
-	for _, c := range chunk(allIDs, 5000) {
-		tsv, err := r.ch.QueryTSV(ctx, "SELECT id FROM "+r.t("pages")+" WHERE crawl_id="+r.cid()+" AND id IN ("+quoteList(c)+")")
-		if err != nil {
-			return err
-		}
-		for _, row := range tsv {
-			if len(row) > 0 {
-				existing[strings.TrimSpace(row[0])] = true
-			}
-		}
+	// 2) which sitemap ids already exist as CH pages (reached by the crawl)?
+	//    Skipping those means we never write a second row per id (which would
+	//    corrupt duplicate detection / in_crawl).
+	existing, err := r.existingPageIDs(ctx, allIDs)
+	if err != nil {
+		return err
 	}
 
 	allowed := generalStrings(raw, "domains")
 	if len(allowed) == 0 {
 		allowed = []string{domain}
 	}
+
+	// 3) fetch the in-scope URLs only the sitemap knows about, BEFORE writing any
+	//    placeholder — so a URL that answers gets a real row (code, title, depth
+	//    -1) instead of an empty shell, and we never write two rows for one id.
+	//    The PG path inserts first and lets the fetch UPDATE the row; ClickHouse
+	//    is append-only, so here the order has to be the other way round.
+	//    FetchURLs flushes the CH store before returning, so re-reading the page
+	//    ids below sees everything the pass just wrote.
+	if r.SitemapFetch != nil {
+		var toFetch []string
+		for id, u := range idToURL {
+			if !existing[id] && urlInScope(u, allowed) {
+				toFetch = append(toFetch, u)
+			}
+		}
+		if len(toFetch) > 0 {
+			sort.Strings(toFetch) // deterministic order → reproducible logs/runs
+			r.logf("ch-sitemap: fetching %d in-scope sitemap-only URL(s)", len(toFetch))
+			if err := r.SitemapFetch(ctx, toFetch, allowed); err != nil {
+				// Non-fatal: whatever could not be fetched simply stays a
+				// placeholder, which is still better than losing the step.
+				r.logf("ch-sitemap: fetch error: %v", err)
+			}
+			if existing, err = r.existingPageIDs(ctx, allIDs); err != nil {
+				return err
+			}
+		}
+	}
+
+	// 4) whatever is still missing stays a sitemap-only placeholder: out-of-scope
+	//    URLs (never fetched by design) and in-scope ones the fetch could not
+	//    bring in. They keep the "declared but absent" signal intact.
 	batch := make([]any, 0, 2000)
 	flush := func() error {
 		if len(batch) == 0 {
@@ -290,6 +324,25 @@ func (r *CHRunner) loadSitemap(ctx context.Context) error {
 	}
 	r.logf("ch-sitemap: %d in crawl, %d sitemap-only placeholder(s)", len(existing), placeholders)
 	return nil
+}
+
+// existingPageIDs returns which of the given page ids already have a row in CH
+// `pages` for this crawl. Called twice by loadSitemap: once to decide what to
+// fetch, once after the fetch to see what it brought in.
+func (r *CHRunner) existingPageIDs(ctx context.Context, ids []string) (map[string]bool, error) {
+	existing := make(map[string]bool, len(ids))
+	for _, c := range chunk(ids, 5000) {
+		tsv, err := r.ch.QueryTSV(ctx, "SELECT id FROM "+r.t("pages")+" WHERE crawl_id="+r.cid()+" AND id IN ("+quoteList(c)+")")
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range tsv {
+			if len(row) > 0 {
+				existing[strings.TrimSpace(row[0])] = true
+			}
+		}
+	}
+	return existing, nil
 }
 
 // optimizeFinal merges this crawl's partitions so subsequent report reads work

--- a/web/project.php
+++ b/web/project.php
@@ -1432,6 +1432,10 @@ if (isset($_GET['ajax']) && $_GET['ajax'] === 'history') {
         });
         const enableAuth = document.getElementById('enable_auth').checked;
         const formData = {
+            // On crawle DANS ce projet : sans cet id le backend re-déduit le projet
+            // du domaine de l'URL de départ, crée un projet vide dès que ça ne matche
+            // pas au caractère près, et la catégorisation repart du template.
+            project_id: <?= (int) $projectId ?>,
             crawl_type: crawlType,
             user_agent: document.getElementById('user_agent').value,
             allowed_domains: document.getElementById('allowed_domains').value.trim().split('\n').filter(d=>d.trim()),


### PR DESCRIPTION
Two independent fixes, both about losing information a crawl should have carried.

---

# 1. Sitemap-only URLs were never fetched in full-ClickHouse mode

## What's broken

`loadSitemap` records every URL the sitemap declares but the crawl never reached as a `depth = -1` placeholder — an empty row: code `0`, no title, no indexability signal.

So the sitemap report can say *"N URLs are in the sitemap only"* without being able to say whether any of them answers 200, 404, or is noindexed. That second half is the part that makes the report actionable.

## Why

The fetch pass already exists: `pp.SitemapFetch`, a skip-link-extraction crawl over exactly those URLs. It was only ever handed to the **PostgreSQL** post-processor — precisely the one that is skipped when ClickHouse is the sole store (`CLICKHOUSE_DROP_PG=1`):

```go
if dropPG {
    milestone("ClickHouse is the sole store (CLICKHOUSE_DROP_PG=1) — skipping PostgreSQL post-processing")
} else {
    pp.Run(ctx)   // ← the only caller of SitemapFetch
}
```

In that mode nothing ever fetched them. Dual-write installs were unaffected: the PG runner still did it there.

## The fix

Hand the same callback to the CH runner, and call it **before** writing any placeholder.

The ordering is the one non-obvious part. The PG path inserts placeholders first and lets the fetch `UPDATE` those rows. ClickHouse is append-only, so doing that here would leave two rows for one id — which is exactly what the existing comment in this function warns against ("Skipping the existing ones means we never write a second row per id, which would corrupt duplicate detection / in_crawl"). So the order is reversed: fetch → re-read the page ids → only what is still missing becomes a placeholder.

Re-reading is safe because `Engine.FetchURLs` flushes the CH store before returning:

```go
func (e *Engine) FetchURLs(ctx context.Context, urls []string) error {
	e.processURLs(ctx, urls, -1)
	e.chStore.Flush(ctx) // drain the sitemap-pass pages/html into ClickHouse
	return e.cdb.UpdateCrawlStats(ctx)
}
```

What still becomes a placeholder: out-of-scope URLs (never fetched by design) and in-scope ones the fetch could not bring in. The "declared but absent" signal stays intact. A fetch failure is logged and non-fatal.

**Invariants unchanged**: fetched sitemap pages keep `depth = -1`, so the read shim still classifies them `in_crawl = FALSE` and PageRank still excludes them via `pdCrawl()`. No schema change, no migration.

---

# 2. A new crawl reset the project's categorization

## What's broken

Starting a new crawl from a project page reset the URL segmentation to the blank `cat.yml` template, so the configuration had to be redone every time — unlike Quick crawl, which duplicates the previous crawl and keeps it.

Two independent causes, one symptom.

### The project was re-derived from the domain

`createProject()` posted to `/api/projects` with **no project id**, and the controller did `getOrCreate(userId, host(start_url))`.

That guesses wrong whenever:
- the start URL does not match the project name character for character — `www.example.com` vs bare, a subdomain, another section;
- or the project is **shared**: `getOrCreate` only looks at projects the user OWNS.

Either way a fresh empty project was created behind the user's back. No history to inherit from, so the categorization fell through to the generic template — and the crawl landed in a phantom project rather than the one on screen.

The page now sends its project id and the controller uses it, behind a `requireProjectManagement()` check.

### The API path never inherited at all

`ApiV1Controller::applyDefaultCategorization` applied `cat.yml` unconditionally, so creating a crawl through the public API — or the MCP `create_crawl` tool — wiped the segmentation of a project that already had one.

## The fix

The inheritance chain (last crawl of the project that has one → project default → `cat.yml` template) moves into `App\Database\CategorizationRepository`, used by both paths so they cannot drift apart again.

## Two things found on the way

- **Scheduler**: when a schedule carries no categorization snapshot, the crawl got none at all. It now falls back to the same chain. It still prefers its own frozen snapshot when it has one — and that snapshot is *not* refreshed when the segmentation is edited, so scheduled crawls can resurrect an old config. Left alone here: it is a separate behaviour change, worth its own decision.
- **`scheduler.php` did not load the Composer autoloader** — it hand-required the single class it used, which breaks silently the moment it touches any other `App\` class. Autoloader added.

---

## Validation

**Go** (`crawler-go/`)
- `go build ./...`
- `go test ./...` — 8 packages, no failures
- `go vet ./internal/postprocess/ ./cmd/...` — clean
- `gofmt` — clean on both changed files

**PHP**
- `php -l` on every changed file
- Full Pest suite identical to the branch baseline: 444 tests, 0 failures (the 101 errors are `PostgreSQL connection refused` — no database in the sandbox — present on an untouched tree too)
- `CategorizationRepository` class loading and `{dom}` substitution checked at runtime

## Files

| | |
|---|---|
| `crawler-go/cmd/scouter-crawler/main.go` | hand `SitemapFetch` to the CH runner |
| `crawler-go/internal/postprocess/clickhouse.go` | fetch step in `loadSitemap`, `existingPageIDs()` helper |
| `app/Database/CategorizationRepository.php` | **new** — the shared inheritance chain |
| `app/Http/Controllers/ProjectController.php` | honour the posted `project_id`, use the shared chain |
| `app/Http/Controllers/ApiV1Controller.php` | inherit instead of always applying the blank template |
| `app/bin/scheduler.php` | fallback to the chain, Composer autoloader |
| `web/project.php` | send the current `project_id` |