### PR TITLE
fix: filtered CSV exports failing, and icons rendering as ligature names

### DIFF
--- a/app/Export/ExportScope.php
+++ b/app/Export/ExportScope.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Export;
+
+use App\Settings\AppSettings;
+
+/**
+ * Signature of a table's WHERE clause ("export scope").
+ *
+ * An async export re-runs, worker-side, the query the user was looking at. The
+ * only practical way to guarantee "the CSV matches the screen" is to replay the
+ * table's own WHERE clause — but that clause travels through the browser, so the
+ * worker cannot trust it: a crafted `report_where` would otherwise let an
+ * authenticated user bolt an arbitrary sub-SELECT onto the export query.
+ *
+ * So the server signs the clause it rendered, and the export endpoint only
+ * accepts clauses carrying a valid signature. The client can replay what the
+ * server produced and nothing else — which is exactly what "export what I see"
+ * needs, and it lets legitimate report scopes keep their sub-SELECTs (lost-urls
+ * / new-urls compare against another crawl's partition).
+ *
+ * Values are NOT part of the signature: they travel as bound parameters, so they
+ * can only change what a filter matches, never the shape of the query.
+ *
+ * @package    Scouter
+ * @subpackage Export
+ */
+class ExportScope
+{
+    /** Where the per-install signing key lives (generated on first use). */
+    private const SETTING_KEY = 'export.scope_signing_key';
+
+    private static ?string $key = null;
+
+    /** HMAC of a WHERE clause, to be posted alongside it. */
+    public static function sign(string $where): string
+    {
+        return hash_hmac('sha256', self::normalize($where), self::key());
+    }
+
+    /** Whether $signature was produced by this install for $where. */
+    public static function verify(string $where, string $signature): bool
+    {
+        if ($signature === '' || $where === '') {
+            return false;
+        }
+        return hash_equals(self::sign($where), $signature);
+    }
+
+    /**
+     * Whitespace-insensitive: the clause round-trips through an HTML attribute
+     * and a JSON body, and report pages build it with newlines/indentation.
+     */
+    private static function normalize(string $where): string
+    {
+        return trim((string)preg_replace('/\s+/', ' ', $where));
+    }
+
+    private static function key(): string
+    {
+        if (self::$key !== null) {
+            return self::$key;
+        }
+        $key = AppSettings::get(self::SETTING_KEY);
+        if ($key === null || $key === '') {
+            $key = bin2hex(random_bytes(32));
+            AppSettings::set(self::SETTING_KEY, $key);
+            // Re-read: a concurrent request may have won the INSERT, and both
+            // sides must end up signing with the same key.
+            AppSettings::flushCache();
+            $key = AppSettings::get(self::SETTING_KEY) ?: $key;
+        }
+        self::$key = $key;
+        return $key;
+    }
+}

--- a/app/Export/ExportService.php
+++ b/app/Export/ExportService.php
@@ -6,6 +6,7 @@ use App\Database\PostgresDatabase;
 use App\Database\CrawlDatabase;
 use App\Database\CrawlStore;
 use App\Database\ChPdo;
+use App\Database\PgReportPdo;
 use App\Database\ClickHouseDatabase;
 use App\Job\JobManager;
 use App\AI\SqlExecutor;
@@ -155,7 +156,11 @@ class ExportService
         $type = $export['type'];
         $params = json_decode($export['params'] ?? '{}', true) ?: [];
         $useCh = CrawlStore::usesClickHouse($crawlId);
-        $dataDb = $useCh ? new ChPdo($crawlId) : $this->db;
+        // PgReportPdo (not the bare connection): legacy PG crawls have no stored
+        // category either — the shim injects the same live `category` column the
+        // explorers read, so `category` exports a real name instead of blowing up
+        // on an unknown column.
+        $dataDb = $useCh ? new ChPdo($crawlId) : new PgReportPdo($crawlId);
 
         // ClickHouse crawls can hold tens of millions of rows: EVERY type STREAMS
         // ClickHouse's own CSV output straight to disk instead of buffering rows
@@ -186,7 +191,7 @@ class ExportService
                 }
             } else {
                 $rowCount = match ($type) {
-                    'urls'      => $this->writeUrls($fh, $crawlId, (int)$export['project_id'], $params, $useCh, $dataDb),
+                    'urls'      => $this->writeUrls($fh, $crawlId, $params, $dataDb),
                     'links'     => $this->writeLinks($fh, $crawlId, $params, $dataDb),
                     'redirects' => $this->writeRedirects($fh, $crawlId, $dataDb),
                     'sql'       => $this->writeSql($fh, $crawlId, (string)($params['sql'] ?? ''), $useCh),
@@ -330,64 +335,24 @@ class ExportService
     // -------------------------------------------------------------------------
 
     /** @param array<string,mixed> $params */
-    private function writeUrls($fh, int $crawlId, int $projectId, array $params, bool $useCh, $dataDb): int
+    private function writeUrls($fh, int $crawlId, array $params, $dataDb): int
     {
-        $search = (string)($params['search'] ?? '');
-        $filters = $params['filters'] ?? [];
-        if (is_string($filters)) {
-            $filters = json_decode($filters, true) ?: [];
-        }
-        $columns = $params['columns'] ?? ['url'];
-        if (is_string($columns)) {
-            $columns = json_decode($columns, true) ?: ['url'];
-        }
+        $columns = $this->decodeColumns($params['columns'] ?? '', ['url']);
+        [$sql, $sqlParams] = $this->buildUrlsSelect($crawlId, $params);
 
-        // Project categories (id → name) for the legacy PG path.
-        $categoriesMap = [];
-        $catStmt = $this->db->prepare("SELECT id, cat FROM crawl_categories WHERE project_id = :pid");
-        $catStmt->execute([':pid' => $projectId]);
-        while ($c = $catStmt->fetch(PDO::FETCH_ASSOC)) {
-            $categoriesMap[$c['id']] = $c['cat'];
-        }
+        $stmt = $dataDb->prepare($sql);
+        $stmt->execute($this->usedParams($sql, $sqlParams));
 
-        $where = ["c.crawl_id = " . (int)$crawlId, "c.crawled = true", "c.in_crawl = TRUE"];
-        $sqlParams = [];
-        if ($search !== '') {
-            $where[] = "c.url LIKE :search";
-            $sqlParams[':search'] = '%' . $search . '%';
-        }
-        if (!empty($filters) && isset($filters['items'])) {
-            $conds = $this->buildFilterConditions($filters['items'], $sqlParams);
-            if (!empty($conds)) {
-                $logic = strtoupper($filters['logic'] ?? 'AND');
-                if (!in_array($logic, ['AND', 'OR'], true)) $logic = 'AND';
-                $where[] = '(' . implode(' ' . $logic . ' ', $conds) . ')';
-            }
-        }
-        // Report scope — SELECT-safe boolean conditions only (same guard as before).
-        $reportWhere = preg_replace('/^\s*WHERE\s+/i', '', trim((string)($params['report_where'] ?? '')));
-        if ($reportWhere !== ''
-            && !preg_match('/[;]|--|\/\*|\*\/|\b(union|select|insert|update|delete|drop|alter|create|grant|truncate|into|information_schema|pg_catalog|system)\b/i', $reportWhere)) {
-            $where[] = '(' . $reportWhere . ')';
-        }
-
-        $catSelect = $useCh ? ", c.category AS _category" : "";
-        $query = "SELECT c.*{$catSelect} FROM pages c WHERE " . implode(' AND ', $where) . " ORDER BY c.pri DESC";
-        $stmt = $dataDb->prepare($query);
-        $stmt->execute($sqlParams);
-
-        fputcsv($fh, $columns, ';');
+        // The SELECT is built from the same column list, so the CSV header and the
+        // row keys line up 1:1 (unknown/unavailable keys are dropped from both).
+        $emitted = $this->urlExportColumns($columns);
+        fputcsv($fh, $emitted, ';');
         $n = 0;
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $line = [];
-            foreach ($columns as $col) {
-                if ($col === 'category') {
-                    $line[] = $useCh
-                        ? ((($row['_category'] ?? '') !== '') ? $row['_category'] : 'Non catégorisé')
-                        : ($categoriesMap[$row['cat_id']] ?? 'Non catégorisé');
-                } else {
-                    $line[] = $row[$col] ?? '';
-                }
+            foreach ($emitted as $col) {
+                $v = $row[$col] ?? '';
+                $line[] = ($col === 'category' && ($v === '' || $v === null)) ? 'Non catégorisé' : $v;
             }
             fputcsv($fh, $line, ';');
             $n++;
@@ -398,27 +363,33 @@ class ExportService
     /** @param array<string,mixed> $params */
     private function writeLinks($fh, int $crawlId, array $params, $dataDb): int
     {
-        $columns = $params['columns'] ?? ['source_url', 'target_url'];
-        if (is_string($columns)) {
-            $columns = json_decode($columns, true) ?: ['source_url', 'target_url'];
-        }
+        $columns = $this->decodeColumns($params['columns'] ?? '', ['source_url', 'target_url']);
+        $select = $this->buildLinkSelectList($columns);
+        $headers = $this->linkExportColumns($columns);
+
+        $sqlParams = [];
+        $scope = $this->reportScope($params, $sqlParams);
+        // Crawl scoping last: it must never be shadowed by a posted param name.
+        $sqlParams = array_merge($sqlParams, [
+            ':crawl_id' => $crawlId, ':crawl_id2' => $crawlId, ':crawl_id3' => $crawlId,
+        ]);
 
         $query = "
-            SELECT cs.url as source_url, ct.url as target_url, l.anchor, l.type, l.nofollow
+            SELECT {$select}
             FROM links l
             JOIN pages cs ON l.src = cs.id AND cs.crawl_id = :crawl_id AND cs.in_crawl = TRUE
             JOIN pages ct ON l.target = ct.id AND ct.crawl_id = :crawl_id2 AND ct.in_crawl = TRUE
-            WHERE l.crawl_id = :crawl_id3
+            WHERE l.crawl_id = :crawl_id3" . ($scope !== '' ? " AND ({$scope})" : '') . "
             ORDER BY cs.url
         ";
         $stmt = $dataDb->prepare($query);
-        $stmt->execute([':crawl_id' => $crawlId, ':crawl_id2' => $crawlId, ':crawl_id3' => $crawlId]);
+        $stmt->execute($this->usedParams($query, $sqlParams));
 
-        fputcsv($fh, $columns, ';');
+        fputcsv($fh, $headers, ';');
         $n = 0;
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $line = [];
-            foreach ($columns as $col) {
+            foreach ($headers as $col) {
                 $line[] = $row[$col] ?? '';
             }
             fputcsv($fh, $line, ';');
@@ -546,6 +517,11 @@ class ExportService
         $columns = $this->decodeColumns($params['columns'] ?? '', ['source_url', 'target_url']);
         $select = $this->buildLinkSelectList($columns);
         $cid = (int)$crawlId;
+        // The link explorer's own WHERE (its filter chips, on cs./ct./l. aliases),
+        // replayed with its params bound — without it the CSV was the whole crawl's
+        // links whatever the on-screen filters said.
+        $sqlParams = [];
+        $scope = $this->reportScope($params, $sqlParams);
         // crawl_id MUST be on the joined pages too. ChPdo::translate scopes each
         // `pages` reference to a per-crawl virtual subquery ONLY when it can read a
         // crawl_id predicate for that alias; without `cs.crawl_id`/`ct.crawl_id`
@@ -557,8 +533,9 @@ class ExportService
         $sql = "SELECT {$select} FROM links l "
             . "JOIN pages cs ON l.src = cs.id AND cs.crawl_id = {$cid} "
             . "JOIN pages ct ON l.target = ct.id AND ct.crawl_id = {$cid} "
-            . "WHERE l.crawl_id = {$cid}";
-        $this->streamPgSqlToFile($fh, $chPdo, $sql, []);
+            . "WHERE l.crawl_id = {$cid}"
+            . ($scope !== '' ? " AND ({$scope})" : '');
+        $this->streamPgSqlToFile($fh, $chPdo, $sql, $sqlParams);
     }
 
     /**
@@ -603,46 +580,209 @@ class ExportService
     private function buildUrlsSelect(int $crawlId, array $params): array
     {
         $columns = $this->decodeColumns($params['columns'] ?? '', ['url']);
-        $search = (string)($params['search'] ?? '');
-        $filters = $params['filters'] ?? [];
-        if (is_string($filters)) {
-            $filters = json_decode($filters, true) ?: [];
-        }
 
-        $where = ["c.crawl_id = " . (int)$crawlId, "c.crawled = true", "c.in_crawl = TRUE"];
+        $where = ["c.crawl_id = " . (int)$crawlId];
         $sqlParams = [];
-        if ($search !== '') {
-            $where[] = "c.url LIKE :search";
-            $sqlParams[':search'] = '%' . $search . '%';
-        }
-        if (!empty($filters) && isset($filters['items'])) {
-            $conds = $this->buildFilterConditions($filters['items'], $sqlParams);
-            if (!empty($conds)) {
-                $logic = strtoupper($filters['logic'] ?? 'AND');
-                if (!in_array($logic, ['AND', 'OR'], true)) $logic = 'AND';
-                $where[] = '(' . implode(' ' . $logic . ' ', $conds) . ')';
+
+        // The table's own WHERE (filters + search, already turned into SQL by the
+        // page that rendered the table) — the export then matches the screen by
+        // construction. Its values travel as BOUND params, never inlined.
+        $scope = $this->reportScope($params, $sqlParams);
+        if ($scope !== '') {
+            // The scope IS the table's row set: adding anything on top (the old
+            // hardcoded `crawled = true AND in_crawl = TRUE`) silently dropped rows
+            // the user could see on screen — uncrawled and sitemap-only URLs.
+            $where[] = '(' . $scope . ')';
+        } else {
+            // No table scope (API caller / legacy payload): keep the historical
+            // default row set and rebuild the WHERE from the raw search + filters.
+            $where[] = 'c.crawled = true';
+            $where[] = 'c.in_crawl = TRUE';
+            $search = (string)($params['search'] ?? '');
+            if ($search !== '') {
+                $where[] = "c.url LIKE :search";
+                $sqlParams[':search'] = '%' . $search . '%';
+            }
+            $conds = $this->buildFilterGroups($params['filters'] ?? [], $sqlParams);
+            if ($conds !== '') {
+                $where[] = $conds;
             }
         }
-        $reportWhere = preg_replace('/^\s*WHERE\s+/i', '', trim((string)($params['report_where'] ?? '')));
-        if ($reportWhere !== ''
-            && !preg_match('/[;]|--|\/\*|\*\/|\b(union|select|insert|update|delete|drop|alter|create|grant|truncate|into|information_schema|pg_catalog|system)\b/i', $reportWhere)) {
-            $where[] = '(' . $reportWhere . ')';
-        }
 
-        // Whitelisted column list → "c.<col> AS <col>". `category` resolves to the
-        // live category once ChPdo.translate runs.
-        $select = [];
-        foreach ($columns as $col) {
-            if (preg_match('/^[a-z_][a-z0-9_]*$/i', $col)) {
-                $select[] = "c.{$col} AS {$col}";
-            }
-        }
-        if (empty($select)) {
-            $select[] = "c.url AS url";
-        }
-
-        $sql = "SELECT " . implode(', ', $select) . " FROM pages c WHERE " . implode(' AND ', $where) . " ORDER BY c.pri DESC";
+        $select = $this->buildUrlSelectList($columns);
+        $sql = "SELECT " . $select . " FROM pages c WHERE " . implode(' AND ', $where) . " ORDER BY c.pri DESC";
         return [$sql, $sqlParams];
+    }
+
+    /**
+     * The page columns an urls export can actually produce, mapped to their SQL
+     * expression (`%s` = the `pages` alias). Mirrors the SELECT built by
+     * web/components/url-table.php so the CSV matches the on-screen table.
+     *
+     * Anything NOT listed here is dropped instead of being emitted blindly as
+     * `c.<key>`: keys like `out_of_scope` (a computed expression), `gsc_*` /
+     * `cmp_*` (join-only columns the export has no join for) are not columns of
+     * `pages`, and shipping them to the database killed the whole export with an
+     * "Unknown identifier" error.
+     */
+    private const URL_COLS = [
+        'url' => 'url', 'domain' => 'domain', 'depth' => 'depth', 'code' => 'code',
+        'category' => 'category', 'inlinks' => 'inlinks', 'outlinks' => 'outlinks',
+        'response_time' => 'response_time', 'schemas' => 'schemas',
+        'compliant' => 'compliant', 'canonical' => 'canonical', 'canonical_value' => 'canonical_value',
+        'noindex' => 'noindex', 'nofollow' => 'nofollow', 'blocked' => 'blocked',
+        'external' => 'external', 'crawled' => 'crawled',
+        'out_of_scope' => '(%s.external = false AND %s.blocked = false AND %s.crawled = false)',
+        'in_sitemap' => 'in_sitemap', 'is_html' => 'is_html', 'redirect_to' => 'redirect_to',
+        'content_type' => 'content_type', 'pri' => 'pri',
+        'title_status' => 'title_status', 'title' => 'title',
+        'h1_status' => 'h1_status', 'h1' => 'h1',
+        'metadesc_status' => 'metadesc_status', 'metadesc' => 'metadesc',
+        'h1_multiple' => 'h1_multiple', 'headings_missing' => 'headings_missing',
+        'word_count' => 'word_count',
+    ];
+
+    /**
+     * SQL expression for one urls-export column key, or null when the key isn't
+     * exportable. `extract_<k>` / `generation_<k>` read the JSONB maps the same
+     * way url-table.php does (ChPdo rewrites `->>` to CH map access).
+     */
+    private function urlColumnExpr(string $alias, string $col): ?string
+    {
+        foreach (['extract_' => 'extracts', 'generation_' => 'generation'] as $prefix => $jsonCol) {
+            if (str_starts_with($col, $prefix)) {
+                $key = substr($col, strlen($prefix));
+                if (!preg_match('/^[a-z0-9_]+$/i', $key)) {
+                    return null;
+                }
+                return "{$alias}.{$jsonCol}->>'{$key}'";
+            }
+        }
+        $tpl = self::URL_COLS[$col] ?? null;
+        if ($tpl === null) {
+            return null;
+        }
+        if (str_contains($tpl, '%s')) {
+            return vsprintf($tpl, array_fill(0, substr_count($tpl, '%s'), $alias));
+        }
+        return "{$alias}.{$tpl}";
+    }
+
+    /**
+     * The requested columns an urls export can actually emit, in order. Both the
+     * CSV header and the SELECT are built from this list, so they can't drift.
+     *
+     * @param string[] $columns
+     * @return string[]
+     */
+    private function urlExportColumns(array $columns): array
+    {
+        $kept = [];
+        foreach ($columns as $col) {
+            if ($this->urlColumnExpr('c', (string)$col) !== null) {
+                $kept[] = (string)$col;
+            }
+        }
+        return $kept ?: ['url'];
+    }
+
+    /** @param string[] $columns */
+    private function buildUrlSelectList(array $columns): string
+    {
+        $select = [];
+        foreach ($this->urlExportColumns($columns) as $col) {
+            $select[] = $this->urlColumnExpr('c', $col) . " AS {$col}";
+        }
+        return implode(', ', $select);
+    }
+
+    /**
+     * The table's own WHERE clause, replayed verbatim with its params BOUND.
+     *
+     * The explorers build their WHERE with PDO placeholders (`c.url LIKE :url_0`)
+     * and keep the values in a separate array. Before this, only the clause was
+     * posted: the placeholders reached the database unbound, which is a syntax
+     * error — every export filtered on anything other than a boolean died there
+     * ("Échec" in the download center, worker exit code 0). Now the values ride
+     * along in `report_params` and are bound like everywhere else.
+     *
+     * The clause is trusted only when it carries this install's signature
+     * ({@see ExportScope}); an unsigned one is still limited to plain boolean
+     * conditions. User-supplied values live in the params, so they never reach
+     * that check — and never reach the SQL text either.
+     *
+     * @param array<string,mixed> $params  the stored export params
+     * @param array<string,mixed> $sqlParams (by ref) receives the bound values
+     */
+    private function reportScope(array $params, array &$sqlParams): string
+    {
+        $raw = trim((string)($params['report_where'] ?? ''));
+        $where = preg_replace('/^\s*WHERE\s+/i', '', $raw);
+        if ($where === '' || $where === '1=1') {
+            return '';
+        }
+        // A signed clause is one this install rendered → replay it as-is, including
+        // the sub-SELECT the lost-urls / new-urls reports need (their scope compares
+        // against another crawl's partition; the old keyword filter silently dropped
+        // it, so those exports quietly returned the WHOLE crawl).
+        if (!ExportScope::verify($raw, (string)($params['report_sig'] ?? ''))) {
+            // Unsigned (API caller, or a tampered payload): only plain boolean
+            // conditions are allowed through.
+            if (preg_match('/[;]|--|\/\*|\*\/|\b(union|select|insert|update|delete|drop|alter|create|grant|truncate|into|information_schema|pg_catalog|system)\b/i', $where)) {
+                throw new \RuntimeException('Export scope rejected: unsigned report_where contains unsafe SQL');
+            }
+        }
+        foreach ($this->decodeReportParams($params['report_params'] ?? []) as $name => $value) {
+            $sqlParams[$name] = $value;
+        }
+        return $where;
+    }
+
+    /**
+     * Normalize the posted report params to `:name => scalar`. Anything that
+     * isn't a plain placeholder/scalar pair is dropped (it could not have come
+     * from a table's PDO param array).
+     *
+     * @param mixed $raw
+     * @return array<string,mixed>
+     */
+    private function decodeReportParams($raw): array
+    {
+        if (is_string($raw)) {
+            $raw = json_decode($raw, true);
+        }
+        if (!is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $name => $value) {
+            if (!is_string($name) || !preg_match('/^:?[a-z_][a-z0-9_]*$/i', $name)) {
+                continue;
+            }
+            if ($value !== null && !is_scalar($value)) {
+                continue;
+            }
+            $out[':' . ltrim($name, ':')] = $value;
+        }
+        return $out;
+    }
+
+    /**
+     * Keep only the params the query actually references — PDO rejects an execute()
+     * carrying a placeholder that isn't in the statement ("Invalid parameter number").
+     *
+     * @param array<string,mixed> $params
+     * @return array<string,mixed>
+     */
+    private function usedParams(string $sql, array $params): array
+    {
+        $used = [];
+        foreach ($params as $name => $value) {
+            if (preg_match('/' . preg_quote($name, '/') . '\b/', $sql)) {
+                $used[$name] = $value;
+            }
+        }
+        return $used;
     }
 
     /**
@@ -653,6 +793,34 @@ class ExportService
      * @param string[] $base
      */
     private function buildLinkSelectList(array $base): string
+    {
+        $map = $this->linkSelectMap($base);
+        $select = [];
+        foreach ($map as $alias => $expr) {
+            $select[] = "{$expr} AS {$alias}";
+        }
+        return implode(', ', $select);
+    }
+
+    /**
+     * The CSV header of a links export — the aliases {@see linkSelectMap} emits,
+     * in the same order, so header and rows can't drift.
+     *
+     * @param string[] $base
+     * @return string[]
+     */
+    private function linkExportColumns(array $base): array
+    {
+        return array_keys($this->linkSelectMap($base));
+    }
+
+    /**
+     * alias => SQL expression for a links export, in output order.
+     *
+     * @param string[] $base
+     * @return array<string,string>
+     */
+    private function linkSelectMap(array $base): array
     {
         // Page-level columns → cs.<expr> / ct.<expr>.
         $page = [
@@ -686,7 +854,10 @@ class ExportService
             if (str_starts_with($col, 'extract_')) {
                 $name = substr($col, strlen('extract_'));
                 if (!preg_match('/^[a-z0-9_]+$/i', $name)) return null;
-                return "{$alias}.extracts['{$name}']";
+                // PG-style JSONB access: ChPdo rewrites `->>` to CH map access, so
+                // the one expression is valid on both stores (the buffered PG path
+                // reuses this very list).
+                return "{$alias}.extracts->>'{$name}'";
             }
             $tpl = $page[$col] ?? null;
             if ($tpl === null) return null;
@@ -699,18 +870,18 @@ class ExportService
 
         $select = [];
         foreach ($urlCols as $col) {
-            if ($e = $exprFor('cs', $col)) $select[] = "{$e} AS source_{$col}";
+            if ($e = $exprFor('cs', $col)) $select["source_{$col}"] = $e;
         }
         foreach ($linkCols as $col) {
-            $select[] = "{$link[$col]} AS {$col}";
+            $select[$col] = $link[$col];
         }
         foreach ($urlCols as $col) {
-            if ($e = $exprFor('ct', $col)) $select[] = "{$e} AS target_{$col}";
+            if ($e = $exprFor('ct', $col)) $select["target_{$col}"] = $e;
         }
         if (empty($select)) {
-            $select = ['cs.url AS source_url', 'ct.url AS target_url'];
+            $select = ['source_url' => 'cs.url', 'target_url' => 'ct.url'];
         }
-        return implode(', ', $select);
+        return $select;
     }
 
     /**
@@ -741,10 +912,78 @@ class ExportService
         return trim((string)$s, '-') ?: 'export';
     }
 
+    /** Page columns the explorers expose as true/false chips (never as a value). */
+    private const BOOL_FILTER_FIELDS = [
+        'compliant', 'canonical', 'noindex', 'nofollow', 'blocked', 'h1_multiple',
+        'headings_missing', 'external', 'in_sitemap', 'is_html', 'crawled',
+    ];
+
+    /** Page columns the explorers filter numerically. */
+    private const NUM_FILTER_FIELDS = [
+        'depth', 'code', 'inlinks', 'outlinks', 'response_time', 'word_count', 'pri',
+    ];
+
     /**
-     * Build parameterized WHERE conditions from the explorer's filter tree.
-     * Column names are whitelisted; values are bound. (Ported from the former
-     * synchronous ExportController.)
+     * Fallback WHERE builder for callers that post a raw filter tree instead of a
+     * table scope (`report_where`) — i.e. the API, not the explorers, which now
+     * replay their own already-built clause.
+     *
+     * Accepts the three shapes seen in the wild: a list of groups
+     * (`[{type:'group',logic,items:[…]}]` — what filter-bar.js puts in the URL),
+     * a single group (`{logic,items:[…]}`), or a bare list of chips. Before this,
+     * only the middle one was understood, so the URL's own filters were silently
+     * ignored and the CSV came back unfiltered.
+     *
+     * @param mixed $filters
+     * @param array<string,mixed> $params (by ref) bound values
+     */
+    private function buildFilterGroups($filters, array &$params): string
+    {
+        if (is_string($filters)) {
+            $filters = json_decode($filters, true);
+        }
+        if (!is_array($filters) || empty($filters)) {
+            return '';
+        }
+        // Single group → wrap it so the list handling below covers both shapes.
+        $groups = isset($filters['items']) ? [$filters] : $filters;
+        if (!array_is_list($groups)) {
+            return '';
+        }
+
+        $out = [];
+        foreach ($groups as $group) {
+            if (!is_array($group)) {
+                continue;
+            }
+            $items = $group['items'] ?? (isset($group['field']) ? [$group] : null);
+            if (!is_array($items)) {
+                continue;
+            }
+            $conds = $this->buildFilterConditions($items, $params);
+            if (empty($conds)) {
+                continue;
+            }
+            $logic = strtoupper((string)($group['logic'] ?? 'AND'));
+            if (!in_array($logic, ['AND', 'OR'], true)) {
+                $logic = 'AND';
+            }
+            $inter = strtoupper((string)($group['interGroupLogic'] ?? 'AND'));
+            if (!in_array($inter, ['AND', 'OR'], true)) {
+                $inter = 'AND';
+            }
+            $clause = '(' . implode(' ' . $logic . ' ', $conds) . ')';
+            $out[] = empty($out) ? $clause : $inter . ' ' . $clause;
+        }
+        return empty($out) ? '' : '(' . implode(' ', $out) . ')';
+    }
+
+    /**
+     * Build parameterized WHERE conditions from a filter tree. Column names are
+     * whitelisted, values are bound, and a chip this builder can't express
+     * EXACTLY like the explorer does is skipped rather than turned into
+     * approximate SQL (a boolean chip used to become `c.external = 'false'`,
+     * which ClickHouse rejects outright since the column is a UInt8).
      *
      * @param array<int,array> $items
      * @param array            $params (by ref)
@@ -755,6 +994,7 @@ class ExportService
         static $counter = 0;
         $conditions = [];
         foreach ($items as $item) {
+            if (!is_array($item)) continue;
             if (isset($item['type']) && $item['type'] === 'group') {
                 $sub = $this->buildFilterConditions($item['items'] ?? [], $params);
                 if (!empty($sub)) {
@@ -764,22 +1004,58 @@ class ExportService
                 }
                 continue;
             }
-            $field = $item['field'] ?? '';
-            $operator = $item['operator'] ?? '=';
+            $field = (string)($item['field'] ?? '');
+            $operator = (string)($item['operator'] ?? '=');
             $value = $item['value'] ?? '';
-            if (empty($field) || !preg_match('/^[a-z_][a-z0-9_]*$/i', $field)) continue;
+            if ($field === '' || !preg_match('/^[a-z_][a-z0-9_]*$/i', $field)) continue;
 
-            $counter++;
-            $p = ':p' . $counter;
+            // Boolean chips carry no operator — `true`/`false` are SQL literals,
+            // not bindable values (the column is a UInt8 on ClickHouse).
+            if (in_array($field, self::BOOL_FILTER_FIELDS, true)) {
+                $conditions[] = "c.{$field} = " . ($value === 'true' || $value === true ? 'true' : 'false');
+                continue;
+            }
+            if ($field === 'out_of_scope') {
+                $expr = '(c.external = false AND c.blocked = false AND c.crawled = false)';
+                $conditions[] = ($value === 'true' || $value === true) ? $expr : "NOT {$expr}";
+                continue;
+            }
+            // category: the chips carry names here (ids are a UI-only concern).
+            if ($field === 'category' && in_array($operator, ['in', 'not_in'], true)) {
+                $names = is_array($value) ? $value : [$value];
+                $ph = [];
+                foreach ($names as $name) {
+                    if (!is_scalar($name)) continue;
+                    $p = ':p' . (++$counter);
+                    $ph[] = $p;
+                    $params[$p] = (string)$name;
+                }
+                if (empty($ph)) continue;
+                $conditions[] = $operator === 'not_in'
+                    ? "(c.category NOT IN (" . implode(',', $ph) . ") OR c.category = '')"
+                    : "c.category IN (" . implode(',', $ph) . ")";
+                continue;
+            }
+            // Everything else is scalar-only: an array value (http-code groups, SEO
+            // status sets, schema types…) has no faithful generic translation.
+            if (!is_scalar($value)) continue;
+
+            $isNum = in_array($field, self::NUM_FILTER_FIELDS, true);
+            $p = ':p' . (++$counter);
             switch ($operator) {
-                case 'contains':      $conditions[] = "c.$field LIKE $p";     $params[$p] = '%' . $value . '%'; break;
-                case 'not_contains':  $conditions[] = "c.$field NOT LIKE $p"; $params[$p] = '%' . $value . '%'; break;
-                case 'starts_with':   $conditions[] = "c.$field LIKE $p";     $params[$p] = $value . '%'; break;
-                case 'ends_with':     $conditions[] = "c.$field LIKE $p";     $params[$p] = '%' . $value; break;
-                case 'is_empty':      $conditions[] = "(c.$field IS NULL OR c.$field = '')"; break;
-                case 'is_not_empty':  $conditions[] = "(c.$field IS NOT NULL AND c.$field != '')"; break;
+                case 'contains':      $conditions[] = "c.{$field} ILIKE {$p}";  $params[$p] = '%' . $value . '%'; break;
+                case 'not_contains':  $conditions[] = "(c.{$field} NOT ILIKE {$p} OR c.{$field} IS NULL)"; $params[$p] = '%' . $value . '%'; break;
+                case 'starts_with':   $conditions[] = "c.{$field} ILIKE {$p}";  $params[$p] = $value . '%'; break;
+                case 'ends_with':     $conditions[] = "c.{$field} ILIKE {$p}";  $params[$p] = '%' . $value; break;
+                case 'regex':         $conditions[] = "c.{$field} ~* {$p}";     $params[$p] = (string)$value; break;
+                case 'not_regex':     $conditions[] = "(c.{$field} !~* {$p} OR c.{$field} IS NULL)"; $params[$p] = (string)$value; break;
+                case 'is_empty':      $conditions[] = "(c.{$field} IS NULL OR c.{$field} = '')"; break;
+                case 'is_not_empty':  $conditions[] = "(c.{$field} IS NOT NULL AND c.{$field} != '')"; break;
                 case '>': case '<': case '>=': case '<=': case '=': case '!=':
-                    $conditions[] = "c.$field $operator $p"; $params[$p] = $value; break;
+                    if (!$isNum) { $conditions[] = "c.{$field} {$operator} {$p}"; $params[$p] = (string)$value; break; }
+                    $conditions[] = "c.{$field} {$operator} {$p}";
+                    $params[$p] = ($field === 'pri' || $field === 'response_time') ? (float)$value : (int)$value;
+                    break;
             }
         }
         return $conditions;

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -87,14 +87,25 @@ class ExportController extends Controller
         switch ($type) {
             case 'urls':
                 $params = [
-                    'filters'      => $request->get('filters', ''),
-                    'search'       => $request->get('search', ''),
-                    'columns'      => $request->get('columns', ''),
-                    'report_where' => $request->get('report_where', ''),
+                    'filters'       => $request->get('filters', ''),
+                    'search'        => $request->get('search', ''),
+                    'columns'       => $request->get('columns', ''),
+                    // The table's WHERE + the values its placeholders bind to. Both
+                    // are needed: posting the clause alone left `:url_0` & co unbound
+                    // in the worker's query, which the database rejects — that is what
+                    // made filtered exports fail.
+                    'report_where'  => $request->get('report_where', ''),
+                    'report_params' => $request->get('report_params', ''),
+                    'report_sig'    => $request->get('report_sig', ''),
                 ];
                 break;
             case 'links':
-                $params = ['columns' => $request->get('columns', '')];
+                $params = [
+                    'columns'       => $request->get('columns', ''),
+                    'report_where'  => $request->get('report_where', ''),
+                    'report_params' => $request->get('report_params', ''),
+                    'report_sig'    => $request->get('report_sig', ''),
+                ];
                 break;
             case 'redirects':
                 $params = [];

--- a/scouter.php
+++ b/scouter.php
@@ -157,6 +157,11 @@ switch($module){
             $jobManager->addLog($jobId, "Export failed: " . $e->getMessage(), 'error');
         }
         echo "\n\nERROR: " . $e->getMessage() . "\n";
+        // Exit non-zero so the worker's own log doesn't report a failed export as
+        // "exit code: 0" (which reads like a success and sends you hunting in the
+        // wrong place). The job/export rows are already terminal, so the worker's
+        // reconciliation leaves them untouched.
+        exit(1);
     }
   break;
 

--- a/tests/Unit/ExportQueryTest.php
+++ b/tests/Unit/ExportQueryTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use App\Export\ExportScope;
+use App\Export\ExportService;
+
+/**
+ * Query building of the async CSV exports.
+ *
+ * These pin the contract that broke filtered exports in production: the worker
+ * re-runs the table's query from the posted params, so the SELECT may only
+ * contain columns that exist, and the WHERE clause's placeholders must arrive
+ * with their values. A miss on either side is not a wrong CSV — it is a database
+ * error, i.e. an export that shows up as "Échec" in the download center.
+ *
+ * ExportService only needs its PDO for the exports table, never for building a
+ * query, so these run without a database (private API reached by reflection).
+ */
+
+function exportService(): ExportService
+{
+    return (new ReflectionClass(ExportService::class))->newInstanceWithoutConstructor();
+}
+
+/** @param array<int,mixed> $args */
+function exportCall(string $method, array $args)
+{
+    $m = new ReflectionMethod(ExportService::class, $method);
+    $m->setAccessible(true);
+    return $m->invokeArgs(exportService(), $args);
+}
+
+// ---------------------------------------------------------------- columns ---
+
+it('maps every exportable url column to a real SQL expression', function () {
+    $select = exportCall('buildUrlSelectList', [['url', 'out_of_scope', 'extract_price', 'generation_intent']]);
+
+    expect($select)->toContain('c.url AS url');
+    // Computed in url-table.php, NOT a column of `pages`.
+    expect($select)->toContain('(c.external = false AND c.blocked = false AND c.crawled = false) AS out_of_scope');
+    // PG-style JSONB access — ChPdo rewrites `->>` to ClickHouse map access.
+    expect($select)->toContain("c.extracts->>'price' AS extract_price");
+    expect($select)->toContain("c.generation->>'intent' AS generation_intent");
+});
+
+it('drops column keys the export cannot produce instead of emitting c.<key>', function () {
+    // gsc_* / cmp_* come from joins the export does not have; emitting them blindly
+    // made ClickHouse fail the whole query with "Unknown identifier".
+    $select = exportCall('buildUrlSelectList', [['url', 'gsc_clicks', 'cmp_depth', 'nope']]);
+
+    expect($select)->toBe('c.url AS url');
+});
+
+it('keeps the CSV header aligned with the SELECT', function () {
+    $cols = ['url', 'gsc_clicks', 'depth'];
+
+    expect(exportCall('urlExportColumns', [$cols]))->toBe(['url', 'depth']);
+});
+
+it('falls back to url when no requested column is exportable', function () {
+    expect(exportCall('urlExportColumns', [['gsc_ctr']]))->toBe(['url']);
+});
+
+// ----------------------------------------------------------- report scope ---
+
+it('replays the table WHERE clause with its placeholders bound', function () {
+    // What the URL Explorer posts: a clause built with PDO params. Posting the
+    // clause alone left `:url_0` unbound in the worker's query → SQL error.
+    [$sql, $params] = exportCall('buildUrlsSelect', [42, [
+        'columns'       => '["url"]',
+        'report_where'  => 'WHERE 1=1 AND ((c.url LIKE :url_0 AND c.depth > :param_1))',
+        'report_params' => '{":url_0":"%/blog/%",":param_1":2}',
+    ]]);
+
+    expect($sql)->toContain('c.crawl_id = 42');
+    expect($sql)->toContain('c.url LIKE :url_0');
+    expect($params)->toBe([':url_0' => '%/blog/%', ':param_1' => 2]);
+});
+
+it('does not narrow the row set the table showed', function () {
+    // The scope IS the table's row set: re-adding crawled/in_crawl on top dropped
+    // uncrawled and sitemap-only URLs the user could see on screen.
+    [$sql] = exportCall('buildUrlsSelect', [42, [
+        'report_where' => 'WHERE 1=1 AND ((c.external = false))',
+    ]]);
+
+    expect($sql)->not->toContain('c.crawled = true');
+    expect($sql)->toContain('c.external = false');
+});
+
+it('keeps the historical default row set when no scope is posted', function () {
+    [$sql] = exportCall('buildUrlsSelect', [42, ['columns' => '["url"]']]);
+
+    expect($sql)->toContain('c.crawled = true');
+    expect($sql)->toContain('c.in_crawl = TRUE');
+});
+
+it('rejects an unsigned scope carrying a sub-SELECT', function () {
+    exportCall('buildUrlsSelect', [42, ['report_where' => 'WHERE c.url NOT IN (SELECT url FROM users)']]);
+})->throws(RuntimeException::class, 'unsigned');
+
+it('accepts a signed scope carrying a sub-SELECT (lost-urls / new-urls)', function () {
+    // Their scope compares against another crawl's partition; the keyword filter
+    // used to drop it silently, so those exports returned the whole crawl.
+    $where = 'WHERE c.crawled = true AND c.url NOT IN (SELECT url FROM pages_7 WHERE crawled = true)';
+    [$sql] = exportCall('buildUrlsSelect', [42, [
+        'report_where' => $where,
+        'report_sig'   => ExportScope::sign($where),
+    ]]);
+
+    expect($sql)->toContain('NOT IN (SELECT url FROM pages_7');
+});
+
+it('signs whitespace-insensitively but rejects a tampered clause', function () {
+    $where = 'WHERE c.depth > 2';
+    $sig = ExportScope::sign($where);
+
+    expect(ExportScope::verify("WHERE   c.depth  >  2", $sig))->toBeTrue();
+    expect(ExportScope::verify('WHERE c.depth > 2 OR 1=1', $sig))->toBeFalse();
+    expect(ExportScope::verify($where, ''))->toBeFalse();
+});
+
+it('drops report params that are not plain placeholder/scalar pairs', function () {
+    $decoded = exportCall('decodeReportParams', [[
+        'url_0'      => 'ok',       // normalized to :url_0
+        ':bad name'  => 'x',
+        ':arr'       => ['a'],
+    ]]);
+
+    expect($decoded)->toBe([':url_0' => 'ok']);
+});
+
+it('only binds the params the query references', function () {
+    // PDO rejects an execute() carrying a placeholder absent from the statement.
+    $used = exportCall('usedParams', ['SELECT 1 WHERE a = :cat_1', [':cat_1' => 'x', ':cat_10' => 'y']]);
+
+    expect($used)->toBe([':cat_1' => 'x']);
+});
+
+// --------------------------------------------------------------- filters ----
+
+it('understands the list-of-groups filter payload the UI produces', function () {
+    // filter-bar.js posts [{type:group,logic,items:[…]}]; only a single
+    // {items:[…]} object was read, so the filters never reached the CSV.
+    $params = [];
+    $where = exportCall('buildFilterGroups', [
+        '[{"type":"group","logic":"OR","items":[{"field":"external","operator":null,"value":"false"},{"field":"depth","operator":">","value":"3"}]}]',
+        &$params,
+    ]);
+
+    expect($where)->toContain('c.external = false');
+    expect($where)->toContain('c.depth > :p');
+    expect(array_values($params))->toBe([3]);
+});
+
+it('emits booleans as SQL literals, never as bound strings', function () {
+    // `c.external = 'false'` is a type error on ClickHouse (the column is UInt8).
+    $params = [];
+    $where = exportCall('buildFilterGroups', [[['field' => 'compliant', 'value' => 'true']], &$params]);
+
+    expect($where)->toContain('c.compliant = true');
+    expect($params)->toBe([]);
+});
+
+it('skips array-valued chips it cannot translate faithfully', function () {
+    // An http-code group used to be stringified into `c.code = 'Array'`.
+    $params = [];
+    $where = exportCall('buildFilterGroups', [[['field' => 'code', 'value' => ['4xx']]], &$params]);
+
+    expect($where)->toBe('');
+});
+
+// ----------------------------------------------------------------- links ----
+
+it('builds link columns for both endpoints with a matching header', function () {
+    $cols = ['url', 'anchor', 'extract_price'];
+    $map = exportCall('linkSelectMap', [$cols]);
+
+    expect(array_keys($map))->toBe(exportCall('linkExportColumns', [$cols]));
+    expect($map['source_url'])->toBe('cs.url');
+    expect($map['target_url'])->toBe('ct.url');
+    expect($map['anchor'])->toBe('l.anchor');
+    expect($map['source_extract_price'])->toContain("extracts->>'price'");
+});

--- a/web/assets/downloads.js
+++ b/web/assets/downloads.js
@@ -159,6 +159,18 @@
             body.appendChild(title);
             body.appendChild(meta);
 
+            // A failed export used to show nothing but "Échec" — the reason was
+            // stored (and already returned by /api/exports) but never displayed, so
+            // the only way to know why was to dig through the worker logs.
+            if (x.status === 'failed' && x.error) {
+                const err = document.createElement('div');
+                err.className = 'notif-item-meta dl-item-error';
+                err.style.cssText = 'color:#e57373;white-space:normal;word-break:break-word;margin-top:2px;';
+                err.textContent = x.error;
+                err.title = x.error;
+                body.appendChild(err);
+            }
+
             item.appendChild(icon);
             item.appendChild(body);
 

--- a/web/assets/vendor/material-symbols/material-symbols.css
+++ b/web/assets/vendor/material-symbols/material-symbols.css
@@ -3,6 +3,9 @@
   font-family: 'Material Symbols Outlined';
   font-style: normal;
   font-weight: 100 700;
+  /* block: an icon must never be painted with a fallback font — that renders the
+     ligature name as plain text ("rocket_launch") and blows up the layout. */
+  font-display: block;
   src: url(material-symbols-outlined.woff2) format('woff2');
 }
 
@@ -20,4 +23,13 @@
   direction: ltr;
   -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
+}
+
+/* `font-display: block` only covers the browser's block period (~3s): past it,
+   the fallback font paints the ligature name until the font finally lands. Keep
+   the glyphs invisible — but laid out (`visibility`, not `display`) — until it is
+   really ready. The class is set by partials/icon-font.php, which always ends up
+   setting it (timeout included), so icons can never stay hidden. */
+html:not(.icon-font-ready) .material-symbols-outlined {
+  visibility: hidden;
 }

--- a/web/components/link-table.php
+++ b/web/components/link-table.php
@@ -1646,7 +1646,12 @@ function getColumnLabel($col, $availableColumns, $linkSpecificColumns) {
         window.queueExport({
             type: 'links',
             project: <?= json_encode((string)($crawlId ?? $projectDir)) ?>,
-            columns: JSON.stringify(selectedCols)
+            columns: JSON.stringify(selectedCols),
+            // The table's own WHERE (+ the values its placeholders bind to): without
+            // it the CSV was every link of the crawl, ignoring the filter chips.
+            report_where: <?= json_encode((string)($linkTableConfig['whereClause'] ?? '')) ?>,
+            report_params: <?= json_encode(json_encode($sqlParams ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)) ?>,
+            report_sig: <?= json_encode(\App\Export\ExportScope::sign((string)($linkTableConfig['whereClause'] ?? ''))) ?>
         });
     };
 

--- a/web/components/url-table.php
+++ b/web/components/url-table.php
@@ -585,6 +585,13 @@ $urls = $sql->fetchAll(PDO::FETCH_OBJ);
          the export matches the table, not the whole crawl. Server-validated in
          ExportController (SELECT-safe boolean conditions only). -->
     <input type="hidden" name="report_where" value="<?= htmlspecialchars($urlTableConfig['whereClause'] ?? '', ENT_QUOTES) ?>">
+    <!-- …and the values its placeholders bind to. The clause is built with PDO
+         params (`c.url LIKE :url_0`), so shipping it without them left the worker
+         with unbound placeholders → SQL error → "Échec" in the download center. -->
+    <input type="hidden" name="report_params" value="<?= htmlspecialchars(json_encode($urlTableConfig['sqlParams'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), ENT_QUOTES) ?>">
+    <!-- Signature of the clause above: the worker only replays a WHERE this
+         server rendered, so a hand-crafted one can't reach the database. -->
+    <input type="hidden" name="report_sig" value="<?= htmlspecialchars(\App\Export\ExportScope::sign($urlTableConfig['whereClause'] ?? ''), ENT_QUOTES) ?>">
 </form>
 
 <!-- Résultats -->
@@ -1606,7 +1613,7 @@ $urls = $sql->fetchAll(PDO::FETCH_OBJ);
 
         const params = new URLSearchParams(window.location.search);
         const form = document.getElementById('exportForm_' + componentId);
-        const reportWhere = form ? ((form.querySelector('[name="report_where"]') || {}).value || '') : '';
+        const field = (n) => (form ? ((form.querySelector('[name="' + n + '"]') || {}).value || '') : '');
 
         if (typeof window.queueExport !== 'function') return;
         window.queueExport({
@@ -1615,7 +1622,11 @@ $urls = $sql->fetchAll(PDO::FETCH_OBJ);
             filters: params.get('filters') || '',
             search: params.get('search') || '',
             columns: JSON.stringify(selectedCols),
-            report_where: reportWhere
+            // report_where already contains this table's filters AND its search
+            // (it IS the WHERE the table ran), so the export matches the screen.
+            report_where: field('report_where'),
+            report_params: field('report_params'),
+            report_sig: field('report_sig')
         });
     };
 

--- a/web/dashboard.php
+++ b/web/dashboard.php
@@ -360,7 +360,7 @@ if ($isHtmxFragment) {
     <link rel="stylesheet" href="assets/style.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/responsive.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/crawl-panel.css?v=<?= time() ?>">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <script src="assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>
     <script src="assets/tooltip.js?v=<?= time() ?>"></script>

--- a/web/index.php
+++ b/web/index.php
@@ -358,7 +358,7 @@ if (isset($_GET['partial']) && $_GET['partial'] === 'projects') {
     <link rel="stylesheet" href="assets/responsive.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/crawl-panel.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/home-redesign.css?v=<?= time() ?>">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <style>
         .config-icon {
             font-size: 20px;

--- a/web/login.php
+++ b/web/login.php
@@ -93,7 +93,7 @@ $needsSetup = !$auth->hasUsers();
     <link rel="icon" type="image/png" href="logo.png">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="stylesheet" href="assets/responsive.css">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <style>
         .login-container {
             min-height: 100vh;

--- a/web/pages/admin.php
+++ b/web/pages/admin.php
@@ -29,7 +29,7 @@ $users = $userRepo->getAll();
     <link rel="stylesheet" href="../assets/responsive.css">
     <link rel="stylesheet" href="../assets/crawl-panel.css">
     <link rel="icon" type="image/png" href="/logo.png">
-    <link rel="stylesheet" href="../assets/vendor/material-symbols/material-symbols.css" />
+    <?php $assetBase = '../'; include __DIR__ . '/../partials/icon-font.php'; ?>
     <style>
         .admin-header {
             display: flex;

--- a/web/pages/monitor.php
+++ b/web/pages/monitor.php
@@ -199,7 +199,7 @@ $migPct = $migTotal > 0 ? round(100 * $migCh / $migTotal) : 100;
     <link rel="stylesheet" href="../assets/style.css">
     <link rel="stylesheet" href="../assets/responsive.css">
     <link rel="icon" type="image/png" href="/logo.png">
-    <link rel="stylesheet" href="../assets/vendor/material-symbols/material-symbols.css" />
+    <?php $assetBase = '../'; include __DIR__ . '/../partials/icon-font.php'; ?>
     <!-- customConfirm() : même modal de confirmation que search analytics / project -->
     <script src="../assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>

--- a/web/pages/settings.php
+++ b/web/pages/settings.php
@@ -81,7 +81,7 @@ try {
     <link rel="stylesheet" href="../assets/responsive.css">
     <link rel="stylesheet" href="../assets/crawl-panel.css">
     <link rel="icon" type="image/png" href="/logo.png">
-    <link rel="stylesheet" href="../assets/vendor/material-symbols/material-symbols.css" />
+    <?php $assetBase = '../'; include __DIR__ . '/../partials/icon-font.php'; ?>
     <!-- CodeMirror 5 (bundled locally, no CDN at runtime) — powers the API explorer
          body editor, the syntax-highlighted response, and the multi-language code
          snippets. Modes are loaded dependency-first (php needs clike + htmlmixed). -->

--- a/web/partials/icon-font.php
+++ b/web/partials/icon-font.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Icon font (Material Symbols) — à inclure dans le <head> de TOUTE page qui
+ * affiche des `.material-symbols-outlined`.
+ *
+ * Pourquoi un partial plutôt qu'un simple <link> recopié : la police doit être
+ * demandée le plus tôt possible ET avant tout rendu d'icône. Sans ça, chaque
+ * icône est écrite en clair ("rocket_launch", "tune", "expand_more") tant que la
+ * police n'est pas arrivée — le fichier fait ~3,7 Mo, donc sur une connexion
+ * lente la période de blocage du navigateur expire et c'est la ligature qui
+ * s'affiche, en cassant la mise en page au passage.
+ *
+ * Trois leviers, dans cet ordre :
+ *  1. `rel=preload` : le téléchargement démarre au parsing du <head>, en
+ *     parallèle du CSS, au lieu d'attendre qu'une icône soit rencontrée.
+ *  2. `font-display: block` (dans material-symbols.css) : pas de rendu en police
+ *     de repli pendant la période de blocage.
+ *  3. le garde-fou ci-dessous : les icônes restent invisibles (mais occupent
+ *     leur place — `visibility`, pas `display`) jusqu'à ce que la police soit
+ *     prête, avec révélation forcée au bout de quelques secondes pour ne JAMAIS
+ *     laisser une interface sans icônes si le chargement échoue.
+ *
+ * Variable optionnelle :
+ *  - $assetBase : préfixe de chemin vers /web (ex. '../' depuis pages/).
+ *    Défaut : déduit de $isInSubfolder, sinon ''.
+ */
+$iconFontBase = $assetBase ?? (($isInSubfolder ?? false) ? '../' : '');
+$iconFontDir = $iconFontBase . 'assets/vendor/material-symbols/';
+?>
+<link rel="preload" href="<?= $iconFontDir ?>material-symbols-outlined.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="<?= $iconFontDir ?>material-symbols.css">
+<script>
+/* Doit rester inline et synchrone : il s'exécute après la feuille de style
+   ci-dessus (donc la @font-face est enregistrée) et avant le rendu du body. */
+(function () {
+    var el = document.documentElement;
+    var reveal = function () { el.classList.add('icon-font-ready'); };
+    // Pas d'API Font Loading (vieux navigateur) : on n'a aucun moyen de savoir,
+    // on affiche tout de suite plutôt que de risquer des icônes fantômes.
+    if (!document.fonts || typeof document.fonts.load !== 'function') { reveal(); return; }
+    var done = false;
+    var once = function () { if (!done) { done = true; reveal(); } };
+    try {
+        document.fonts.load('24px "Material Symbols Outlined"').then(once, once);
+    } catch (e) { once(); return; }
+    // Filet de sécurité : police injoignable/lente → on repasse au comportement
+    // d'avant (ligature visible) plutôt que de garder une UI sans icônes.
+    setTimeout(once, 5000);
+})();
+</script>

--- a/web/profile.php
+++ b/web/profile.php
@@ -49,7 +49,7 @@ $barColor = $pct >= 100 ? '#dc2626' : ($pct >= 80 ? '#f59e0b' : 'var(--primary-c
     <link rel="icon" type="image/png" href="logo.png">
     <link rel="stylesheet" href="assets/style.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/responsive.css?v=<?= time() ?>">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <script src="assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>
     <style>

--- a/web/project.php
+++ b/web/project.php
@@ -380,7 +380,7 @@ if (isset($_GET['ajax']) && $_GET['ajax'] === 'history') {
     <link rel="stylesheet" href="assets/responsive.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/crawl-panel.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/project-redesign.css?v=<?= time() ?>">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <script src="assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>
     <script src="assets/tooltip.js?v=<?= time() ?>"></script>

--- a/web/search-analytics.php
+++ b/web/search-analytics.php
@@ -79,7 +79,7 @@ $flashMsg = $_GET['gsc_msg'] ?? '';
     <link rel="stylesheet" href="assets/data-table.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/filter-bar.css?v=<?= time() ?>">
     <link rel="stylesheet" href="assets/gsc.css?v=<?= time() ?>">
-    <link rel="stylesheet" href="assets/vendor/material-symbols/material-symbols.css" />
+    <?php include __DIR__ . '/partials/icon-font.php'; ?>
     <script src="assets/i18n.js"></script>
     <script>ScouterI18n.init(<?= I18n::getInstance()->getJsTranslations() ?>, <?= json_encode(I18n::getInstance()->getLang()) ?>);</script>
     <script src="assets/highcharts.js"></script>


### PR DESCRIPTION
Two unrelated user-visible bugs, both reported from production.

---

## 1. CSV exports fail (or silently ignore the filters)

### Symptom

Exporting from the URL Explorer sometimes ends as **Échec** in the download center, with no reason shown. The worker log looks contradictory:

```
[Worker] Executing CSV export: export:36
[Worker] Crawl finished with exit code: 0
[Worker] Job #3629 - DB status: 'failed', exitCode: 0
```

Exit code 0 with status `failed` means the subprocess caught an exception, marked the export failed itself, then exited 0 — so this is neither an OOM nor a storage problem. The query the worker rebuilds is the thing that errors out.

### Root cause

An async export re-runs, worker-side, the query the user was looking at. `ExportService` **re-implemented** that query instead of replaying it, and drifted from the explorer on three points:

1. **The WHERE clause travelled without its values.** The explorers build `c.url LIKE :url_0 AND c.depth > :param_1` and keep the values in a separate PDO array. Only the clause was posted (`report_where`), so the placeholders reached the database unbound — a syntax error. Any export filtered on something other than a boolean died there. Booleans compile to a literal (`c.external = false`), which is why the failure looked intermittent.
2. **Column keys were emitted blindly as `c.<key>`.** `out_of_scope` is a computed expression, `extract_*` / `generation_*` are JSONB map accesses, `gsc_*` / `cmp_*` come from joins the export doesn't have. None of them are columns of `pages`, so ClickHouse rejected the whole query with *Unknown identifier*.
3. **The filter payload shape was misread.** `filter-bar.js` posts a **list** of groups (`[{type:'group',items:[…]}]`); the service only understood a single `{items:[…]}` object, so the condition was never built and the CSV came back unfiltered.

### Same class of bug on the neighbouring exports

| Export | Before |
| --- | --- |
| **URLs** | the three defects above |
| **Links** | the link explorer's filters were **never sent at all** → CSV = every link of the crawl. On the PostgreSQL path the CSV header used base column keys (`url`, `code`) while the query selected `source_url` / `target_url` → empty cells |
| **Lost URLs / New URLs** | their scope contains a sub-SELECT against the compared crawl's partition; a keyword filter rejected it **silently** → those exports returned the whole crawl instead of the lost/new URLs |
| **Redirects** | fine (that table has no filters) |
| **SQL Explorer** | fine (same validated executor as the UI) |
| **Search Console** | fine (dedicated builder, bound params, whitelisted columns) |

### Fix

The export now **replays the table's own WHERE clause with its parameters bound**, so the CSV matches the screen by construction.

That clause transits through the browser, so it can't be trusted as-is: it is signed server-side (`ExportScope`, HMAC over the clause, per-install key stored in `app_settings`). A signed clause is replayed verbatim — sub-SELECTs included, which is what unblocks lost-urls / new-urls; an unsigned one (API callers) stays limited to plain boolean conditions and is rejected otherwise. Values are always bound parameters, so they can change what a filter matches but never the shape of the query.

Alongside:

- column keys are mapped to the same SQL expressions `url-table.php` uses, and keys the export cannot produce are dropped instead of being sent to the database;
- the raw filter-tree path (API callers) now understands the list-of-groups shape, emits booleans as SQL literals, and skips chips it cannot translate faithfully rather than producing approximate SQL;
- the export no longer re-adds `crawled = true AND in_crawl = TRUE` on top of the table's scope — that quietly dropped uncrawled and sitemap-only rows the user could see on screen;
- legacy PostgreSQL crawls go through `PgReportPdo`, so `category` resolves to the live name like it does in the UI;
- the failure reason is finally **displayed** in the download center (it was already stored and already returned by `/api/exports`, just never rendered);
- a failed export subprocess exits non-zero, so the worker stops logging `exit code: 0` for a job it just marked failed.

---

## 2. Icons rendering as their ligature name

### Symptom

Icons occasionally paint as raw text — `rocket_launch`, `tune`, `speed`, `expand_more` — which also wrecks the layout, since those strings are much wider than a glyph.

### Root cause

Material Symbols is a self-hosted **3.7 MB** woff2 declared with neither `font-display` nor a preload. The browser only starts fetching it when it first lays out an icon, and once the default block period expires it paints with a fallback font — which renders the ligature name.

### Fix

Load it first, everywhere, and never paint an icon before it is ready:

- `rel=preload` so the download starts during head parsing, in parallel with the CSS;
- `font-display: block` so no fallback font is used during the block period;
- a guard that keeps icons invisible **but laid out** (`visibility`, not `display`) past that period, released as soon as `document.fonts` reports the font loaded.

The release is unconditional in the end: no Font Loading API, a throwing call, or a font that never arrives all fall back to the previous behaviour after 5s, so an install can never end up with an icon-less UI. All nine templates that render icons now go through `partials/icon-font.php` (`gsc.php` / `oauth.php` use no icons), so this holds for pages added later.

Worth a follow-up: subsetting that 3.7 MB file to the icons actually used would cut it by orders of magnitude, but it needs a check of every ligature name — including the ones built in JS — so it is deliberately out of scope here.

---

## Tests

`tests/Unit/ExportQueryTest.php` — 15 cases pinning the contract that broke: placeholders arrive bound, unexportable column keys are dropped, header and SELECT stay aligned, the scope is not narrowed, an unsigned sub-SELECT is rejected while a signed one is replayed, the list-of-groups payload is understood, booleans compile to literals. Most run without a database (the service only needs its PDO for the `exports` table).

## How to verify on an existing failed export

```sql
SELECT id, type, status, error FROM exports WHERE status = 'failed' ORDER BY id DESC LIMIT 10;
```

That `error` column is what the download center now shows.